### PR TITLE
Add option for skipping compile command checks

### DIFF
--- a/scripts/check_compile_commands.sh
+++ b/scripts/check_compile_commands.sh
@@ -18,7 +18,7 @@ set -e
 set -u
 set -x
 
-if [ -z "${SHADERTRAP_SKIP_CHECK_COMPILE_COMMANDS}" ]
+if [ -z "${SHADERTRAP_SKIP_CHECK_COMPILE_COMMANDS+x}" ]
 then
   check_clang_tidy.sh "${1}"
   check_cppcheck.sh "${1}"

--- a/scripts/check_compile_commands.sh
+++ b/scripts/check_compile_commands.sh
@@ -18,6 +18,9 @@ set -e
 set -u
 set -x
 
-check_clang_tidy.sh "${1}"
-check_cppcheck.sh "${1}"
-check_iwyu.sh "${1}"
+if [ -z "${SHADERTRAP_SKIP_CHECK_COMPILE_COMMANDS}" ]
+then
+  check_clang_tidy.sh "${1}"
+  check_cppcheck.sh "${1}"
+  check_iwyu.sh "${1}"
+fi


### PR DESCRIPTION
When releasing ShaderTrap based on a commit for which CI has passed,
there is no need to re-run checkers such as clang-tidy and iwyu. This
adds a way to skip such checks.