### PR TITLE
Improvements to the checker

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@
 # holds the copyright.
 
 Google LLC
+Imperial College London

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,3 +6,6 @@
 Google LLC
  Alastair Donaldson
  Paul Thomson
+
+Imperial College London
+ Alastair F. Donaldson

--- a/examples/redtriangle.shadertrap
+++ b/examples/redtriangle.shadertrap
@@ -1,0 +1,58 @@
+# Copyright 2021 The ShaderTrap Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DECLARE_SHADER frag FRAGMENT
+#version 320 es
+precision highp float;
+layout(location = 0) out vec4 color;
+void main() {
+ color = vec4(1.0, 0.0, 0.0, 1.0);
+}
+END
+
+DECLARE_SHADER vert VERTEX
+#version 320 es
+layout(location = 0) in vec2 pos;
+void main(void) {
+    gl_Position = vec4(pos, 0.0, 1.0);
+}
+END
+
+COMPILE_SHADER frag_compiled SHADER frag
+
+COMPILE_SHADER vert_compiled SHADER vert
+
+CREATE_PROGRAM program SHADERS vert_compiled frag_compiled
+
+CREATE_BUFFER vertex_buffer SIZE_BYTES 24 INIT_TYPE float INIT_VALUES
+                           0.0 -1.0
+                           -1.0 1.0
+                            1.0 1.0
+
+CREATE_BUFFER index_buffer SIZE_BYTES 24 INIT_TYPE uint INIT_VALUES
+                           0 1 2 3 4 5
+
+CREATE_RENDERBUFFER renderbuffer WIDTH 256 HEIGHT 256
+
+RUN_GRAPHICS
+  PROGRAM program
+  VERTEX_DATA
+    [ 0 -> BUFFER vertex_buffer OFFSET_BYTES 0 STRIDE_BYTES 8 DIMENSION 2 ]
+  INDEX_DATA index_buffer
+  VERTEX_COUNT 3
+  TOPOLOGY TRIANGLES
+  FRAMEBUFFER_ATTACHMENTS
+    [ 0 -> renderbuffer ]
+
+DUMP_RENDERBUFFER RENDERBUFFER renderbuffer FILE "example_redtriangle.png"

--- a/src/libshadertrap/include/libshadertrap/checker.h
+++ b/src/libshadertrap/include/libshadertrap/checker.h
@@ -113,6 +113,12 @@ class Checker : public CommandVisitor {
   std::unordered_map<std::string, CommandDeclareShader*> declared_shaders_;
   std::unordered_map<std::string, CommandCompileShader*> compiled_shaders_;
   std::unordered_map<std::string, CommandCreateProgram*> created_programs_;
+  std::unordered_map<std::string, CommandCreateBuffer*> created_buffers_;
+  std::unordered_map<std::string, CommandCreateRenderbuffer*>
+      created_renderbuffers_;
+  std::unordered_map<std::string, CommandCreateSampler*> created_samplers_;
+  std::unordered_map<std::string, CommandCreateEmptyTexture2D*>
+      created_textures_;
   std::unordered_map<std::string, std::unique_ptr<glslang::TShader>>
       glslang_shaders_;
 };

--- a/src/libshadertrap/include/libshadertrap/checker.h
+++ b/src/libshadertrap/include/libshadertrap/checker.h
@@ -108,6 +108,11 @@ class Checker : public CommandVisitor {
   static std::string FixLinesInGlslangOutput(const std::string& glslang_output,
                                              size_t line_offset);
 
+  // Requires that |renderbuffer_token_1| and |renderbuffer_token_2| refer to
+  // renderbuffers. Returns true if and only if their widths and heights match.
+  bool CheckRenderbufferDimensionsMatch(const Token& renderbuffer_token_1,
+                                        const Token& renderbuffer_token_2);
+
   MessageConsumer* message_consumer_;
   std::unordered_map<std::string, const Token*> used_identifiers_;
   std::unordered_map<std::string, CommandDeclareShader*> declared_shaders_;

--- a/src/libshadertrap/include/libshadertrap/checker.h
+++ b/src/libshadertrap/include/libshadertrap/checker.h
@@ -126,6 +126,8 @@ class Checker : public CommandVisitor {
       created_textures_;
   std::unordered_map<std::string, std::unique_ptr<glslang::TShader>>
       glslang_shaders_;
+  std::unordered_map<std::string, std::unique_ptr<glslang::TProgram>>
+      glslang_programs_;
 };
 
 }  // namespace shadertrap

--- a/src/libshadertrap/include/libshadertrap/command_assert_equal.h
+++ b/src/libshadertrap/include/libshadertrap/command_assert_equal.h
@@ -26,22 +26,30 @@ namespace shadertrap {
 class CommandAssertEqual : public Command {
  public:
   CommandAssertEqual(std::unique_ptr<Token> start_token,
-                     std::string buffer_identifier_1,
-                     std::string buffer_identifier_2);
+                     std::unique_ptr<Token> buffer_identifier_1,
+                     std::unique_ptr<Token> buffer_identifier_2);
 
   bool Accept(CommandVisitor* visitor) override;
 
   const std::string& GetBufferIdentifier1() const {
-    return buffer_identifier_1_;
+    return buffer_identifier_1_->GetText();
+  }
+
+  const Token* GetBufferIdentifier1Token() const {
+    return buffer_identifier_1_.get();
   }
 
   const std::string& GetBufferIdentifier2() const {
-    return buffer_identifier_2_;
+    return buffer_identifier_2_->GetText();
+  }
+
+  const Token* GetBufferIdentifier2Token() const {
+    return buffer_identifier_2_.get();
   }
 
  private:
-  std::string buffer_identifier_1_;
-  std::string buffer_identifier_2_;
+  std::unique_ptr<Token> buffer_identifier_1_;
+  std::unique_ptr<Token> buffer_identifier_2_;
 };
 
 }  // namespace shadertrap

--- a/src/libshadertrap/include/libshadertrap/command_assert_pixels.h
+++ b/src/libshadertrap/include/libshadertrap/command_assert_pixels.h
@@ -32,7 +32,9 @@ class CommandAssertPixels : public Command {
                       uint8_t expected_a,
                       std::unique_ptr<Token> renderbuffer_identifier,
                       size_t rectangle_x, size_t rectangle_y,
-                      size_t rectangle_width, size_t rectangle_height);
+                      size_t rectangle_width, size_t rectangle_height,
+                      std::unique_ptr<Token> rectangle_width_token,
+                      std::unique_ptr<Token> rectangle_height_token);
 
   bool Accept(CommandVisitor* visitor) override;
 
@@ -60,6 +62,14 @@ class CommandAssertPixels : public Command {
 
   size_t GetRectangleHeight() const { return rectangle_height_; }
 
+  const Token* GetRectangleWidthToken() const {
+    return rectangle_width_token_.get();
+  }
+
+  const Token* GetRectangleHeightToken() const {
+    return rectangle_height_token_.get();
+  }
+
  private:
   uint8_t expected_r_;
   uint8_t expected_g_;
@@ -70,6 +80,8 @@ class CommandAssertPixels : public Command {
   size_t rectangle_y_;
   size_t rectangle_width_;
   size_t rectangle_height_;
+  std::unique_ptr<Token> rectangle_width_token_;
+  std::unique_ptr<Token> rectangle_height_token_;
 };
 
 }  // namespace shadertrap

--- a/src/libshadertrap/include/libshadertrap/command_assert_pixels.h
+++ b/src/libshadertrap/include/libshadertrap/command_assert_pixels.h
@@ -29,7 +29,8 @@ class CommandAssertPixels : public Command {
  public:
   CommandAssertPixels(std::unique_ptr<Token> start_token, uint8_t expected_r,
                       uint8_t expected_g, uint8_t expected_b,
-                      uint8_t expected_a, std::string renderbuffer_identifier,
+                      uint8_t expected_a,
+                      std::unique_ptr<Token> renderbuffer_identifier,
                       size_t rectangle_x, size_t rectangle_y,
                       size_t rectangle_width, size_t rectangle_height);
 
@@ -44,7 +45,11 @@ class CommandAssertPixels : public Command {
   uint8_t GetExpectedA() const { return expected_a_; }
 
   const std::string& GetRenderbufferIdentifier() const {
-    return renderbuffer_identifier_;
+    return renderbuffer_identifier_->GetText();
+  }
+
+  const Token* GetRenderbufferIdentifierToken() const {
+    return renderbuffer_identifier_.get();
   }
 
   size_t GetRectangleX() const { return rectangle_x_; }
@@ -60,7 +65,7 @@ class CommandAssertPixels : public Command {
   uint8_t expected_g_;
   uint8_t expected_b_;
   uint8_t expected_a_;
-  std::string renderbuffer_identifier_;
+  std::unique_ptr<Token> renderbuffer_identifier_;
   size_t rectangle_x_;
   size_t rectangle_y_;
   size_t rectangle_width_;

--- a/src/libshadertrap/include/libshadertrap/command_assert_similar_emd_histogram.h
+++ b/src/libshadertrap/include/libshadertrap/command_assert_similar_emd_histogram.h
@@ -26,25 +26,33 @@ namespace shadertrap {
 class CommandAssertSimilarEmdHistogram : public Command {
  public:
   CommandAssertSimilarEmdHistogram(std::unique_ptr<Token> start_token,
-                                   std::string buffer_identifier_1,
-                                   std::string buffer_identifier_2,
+                                   std::unique_ptr<Token> buffer_identifier_1,
+                                   std::unique_ptr<Token> buffer_identifier_2,
                                    float tolerance);
 
   bool Accept(CommandVisitor* visitor) override;
 
   const std::string& GetBufferIdentifier1() const {
-    return buffer_identifier_1_;
+    return buffer_identifier_1_->GetText();
+  }
+
+  const Token* GetBufferIdentifier1Token() const {
+    return buffer_identifier_1_.get();
   }
 
   const std::string& GetBufferIdentifier2() const {
-    return buffer_identifier_2_;
+    return buffer_identifier_2_->GetText();
+  }
+
+  const Token* GetBufferIdentifier2Token() const {
+    return buffer_identifier_2_.get();
   }
 
   float GetTolerance() const { return tolerance_; }
 
  private:
-  std::string buffer_identifier_1_;
-  std::string buffer_identifier_2_;
+  std::unique_ptr<Token> buffer_identifier_1_;
+  std::unique_ptr<Token> buffer_identifier_2_;
   float tolerance_;
 };
 

--- a/src/libshadertrap/include/libshadertrap/command_bind_sampler.h
+++ b/src/libshadertrap/include/libshadertrap/command_bind_sampler.h
@@ -27,18 +27,23 @@ namespace shadertrap {
 class CommandBindSampler : public Command {
  public:
   CommandBindSampler(std::unique_ptr<Token> start_token,
-                     std::string sampler_identifier, size_t texture_unit_);
+                     std::unique_ptr<Token> sampler_identifier,
+                     size_t texture_unit_);
 
   bool Accept(CommandVisitor* visitor) override;
 
   const std::string& GetSamplerIdentifier() const {
-    return sampler_identifier_;
+    return sampler_identifier_->GetText();
+  }
+
+  const Token* GetSamplerIdentifierToken() const {
+    return sampler_identifier_.get();
   }
 
   size_t GetTextureUnit() const { return texture_unit_; }
 
  private:
-  std::string sampler_identifier_;
+  std::unique_ptr<Token> sampler_identifier_;
   size_t texture_unit_;
 };
 

--- a/src/libshadertrap/include/libshadertrap/command_bind_storage_buffer.h
+++ b/src/libshadertrap/include/libshadertrap/command_bind_storage_buffer.h
@@ -27,19 +27,23 @@ namespace shadertrap {
 class CommandBindStorageBuffer : public Command {
  public:
   CommandBindStorageBuffer(std::unique_ptr<Token> start_token,
-                           std::string storage_buffer_identifier,
+                           std::unique_ptr<Token> buffer_identifier,
                            size_t binding);
 
   bool Accept(CommandVisitor* visitor) override;
 
-  const std::string& GetStorageBufferIdentifier() const {
-    return storage_buffer_identifier_;
+  const std::string& GetBufferIdentifier() const {
+    return buffer_identifier_->GetText();
+  }
+
+  const Token* GetBufferIdentifierToken() const {
+    return buffer_identifier_.get();
   }
 
   size_t GetBinding() const { return binding_; }
 
  private:
-  std::string storage_buffer_identifier_;
+  std::unique_ptr<Token> buffer_identifier_;
   size_t binding_;
 };
 

--- a/src/libshadertrap/include/libshadertrap/command_bind_texture.h
+++ b/src/libshadertrap/include/libshadertrap/command_bind_texture.h
@@ -27,18 +27,23 @@ namespace shadertrap {
 class CommandBindTexture : public Command {
  public:
   CommandBindTexture(std::unique_ptr<Token> start_token,
-                     std::string texture_identifier, size_t texture_unit);
+                     std::unique_ptr<Token> texture_identifier,
+                     size_t texture_unit);
 
   bool Accept(CommandVisitor* visitor) override;
 
   const std::string& GetTextureIdentifier() const {
-    return texture_identifier_;
+    return texture_identifier_->GetText();
+  }
+
+  const Token* GetTextureIdentifierToken() const {
+    return texture_identifier_.get();
   }
 
   size_t GetTextureUnit() const { return texture_unit_; }
 
  private:
-  std::string texture_identifier_;
+  std::unique_ptr<Token> texture_identifier_;
   size_t texture_unit_;
 };
 

--- a/src/libshadertrap/include/libshadertrap/command_bind_uniform_buffer.h
+++ b/src/libshadertrap/include/libshadertrap/command_bind_uniform_buffer.h
@@ -27,19 +27,23 @@ namespace shadertrap {
 class CommandBindUniformBuffer : public Command {
  public:
   CommandBindUniformBuffer(std::unique_ptr<Token> start_token,
-                           std::string uniform_buffer_identifier,
+                           std::unique_ptr<Token> buffer_identifier,
                            size_t binding);
 
   bool Accept(CommandVisitor* visitor) override;
 
-  const std::string& GetUniformBufferIdentifier() const {
-    return uniform_buffer_identifier_;
+  const std::string& GetBufferIdentifier() const {
+    return buffer_identifier_->GetText();
+  }
+
+  const Token* GetBufferIdentifierToken() const {
+    return buffer_identifier_.get();
   }
 
   size_t GetBinding() const { return binding_; }
 
  private:
-  std::string uniform_buffer_identifier_;
+  std::unique_ptr<Token> buffer_identifier_;
   size_t binding_;
 };
 

--- a/src/libshadertrap/include/libshadertrap/command_create_renderbuffer.h
+++ b/src/libshadertrap/include/libshadertrap/command_create_renderbuffer.h
@@ -27,8 +27,8 @@ namespace shadertrap {
 class CommandCreateRenderbuffer : public Command {
  public:
   CommandCreateRenderbuffer(std::unique_ptr<Token> start_token,
-                            std::string result_identifier, size_t width,
-                            size_t height);
+                            std::unique_ptr<Token> result_identifier,
+                            size_t width, size_t height);
 
   bool Accept(CommandVisitor* visitor) override;
 
@@ -36,10 +36,16 @@ class CommandCreateRenderbuffer : public Command {
 
   size_t GetHeight() const { return height_; }
 
-  const std::string& GetResultIdentifier() const { return result_identifier_; }
+  const std::string& GetResultIdentifier() const {
+    return result_identifier_->GetText();
+  }
+
+  const Token* GetResultIdentifierToken() const {
+    return result_identifier_.get();
+  }
 
  private:
-  std::string result_identifier_;
+  std::unique_ptr<Token> result_identifier_;
   size_t width_;
   size_t height_;
 };

--- a/src/libshadertrap/include/libshadertrap/command_dump_renderbuffer.h
+++ b/src/libshadertrap/include/libshadertrap/command_dump_renderbuffer.h
@@ -26,19 +26,23 @@ namespace shadertrap {
 class CommandDumpRenderbuffer : public Command {
  public:
   CommandDumpRenderbuffer(std::unique_ptr<Token> start_token,
-                          std::string renderbuffer_identifier,
+                          std::unique_ptr<Token> renderbuffer_identifier,
                           std::string filename);
 
   bool Accept(CommandVisitor* visitor) override;
 
   const std::string& GetRenderbufferIdentifier() const {
-    return renderbuffer_identifier_;
+    return renderbuffer_identifier_->GetText();
+  }
+
+  const Token* GetRenderbufferIdentifierToken() const {
+    return renderbuffer_identifier_.get();
   }
 
   const std::string& GetFilename() const { return filename_; }
 
  private:
-  std::string renderbuffer_identifier_;
+  std::unique_ptr<Token> renderbuffer_identifier_;
   std::string filename_;
 };
 

--- a/src/libshadertrap/include/libshadertrap/command_run_compute.h
+++ b/src/libshadertrap/include/libshadertrap/command_run_compute.h
@@ -31,13 +31,18 @@ class CommandRunCompute : public Command {
   enum class Topology { kTriangles };
 
   CommandRunCompute(std::unique_ptr<Token> start_token,
-                    std::string program_identifier, size_t num_groups_x,
-                    size_t num_groups_y, size_t num_groups_z);
+                    std::unique_ptr<Token> program_identifier,
+                    size_t num_groups_x, size_t num_groups_y,
+                    size_t num_groups_z);
 
   bool Accept(CommandVisitor* visitor) override;
 
   const std::string& GetProgramIdentifier() const {
-    return program_identifier_;
+    return program_identifier_->GetText();
+  }
+
+  const Token* GetProgramIdentifierToken() const {
+    return program_identifier_.get();
   }
 
   size_t GetNumGroupsX() const { return num_groups_x_; }
@@ -47,8 +52,7 @@ class CommandRunCompute : public Command {
   size_t GetNumGroupsZ() const { return num_groups_z_; }
 
  private:
-  std::string program_identifier_;
-  std::unordered_map<size_t, VertexAttributeInfo> vertex_data_;
+  std::unique_ptr<Token> program_identifier_;
   size_t num_groups_x_;
   size_t num_groups_y_;
   size_t num_groups_z_;

--- a/src/libshadertrap/include/libshadertrap/command_run_compute.h
+++ b/src/libshadertrap/include/libshadertrap/command_run_compute.h
@@ -18,11 +18,9 @@
 #include <cstddef>
 #include <memory>
 #include <string>
-#include <unordered_map>
 
 #include "libshadertrap/command.h"
 #include "libshadertrap/token.h"
-#include "libshadertrap/vertex_attribute_info.h"
 
 namespace shadertrap {
 

--- a/src/libshadertrap/include/libshadertrap/command_run_graphics.h
+++ b/src/libshadertrap/include/libshadertrap/command_run_graphics.h
@@ -31,16 +31,22 @@ class CommandRunGraphics : public Command {
   enum class Topology { kTriangles };
 
   CommandRunGraphics(
-      std::unique_ptr<Token> start_token, std::string program_identifier,
+      std::unique_ptr<Token> start_token,
+      std::unique_ptr<Token> program_identifier,
       std::unordered_map<size_t, VertexAttributeInfo> vertex_data,
-      std::string index_data_buffer_identifier, size_t vertex_count,
+      std::unique_ptr<Token> index_data_buffer_identifier, size_t vertex_count,
       Topology topology,
-      std::unordered_map<size_t, std::string> output_buffers);
+      std::unordered_map<size_t, std::unique_ptr<Token>>
+          framebuffer_attachments);
 
   bool Accept(CommandVisitor* visitor) override;
 
   const std::string& GetProgramIdentifier() const {
-    return program_identifier_;
+    return program_identifier_->GetText();
+  }
+
+  const Token* GetProgramIdentifierToken() const {
+    return program_identifier_.get();
   }
 
   const std::unordered_map<size_t, VertexAttributeInfo>& GetVertexData() const {
@@ -48,25 +54,29 @@ class CommandRunGraphics : public Command {
   }
 
   const std::string& GetIndexDataBufferIdentifier() const {
-    return index_data_buffer_identifier_;
+    return index_data_buffer_identifier_->GetText();
+  }
+
+  const Token* GetIndexDataBufferIdentifierToken() const {
+    return index_data_buffer_identifier_.get();
   }
 
   size_t GetVertexCount() const { return vertex_count_; }
 
   Topology GetTopology() const { return topology_; }
 
-  const std::unordered_map<size_t, std::string>& GetFramebufferAttachments()
-      const {
+  const std::unordered_map<size_t, std::unique_ptr<Token>>&
+  GetFramebufferAttachments() const {
     return framebuffer_attachments_;
   }
 
  private:
-  std::string program_identifier_;
+  std::unique_ptr<Token> program_identifier_;
   std::unordered_map<size_t, VertexAttributeInfo> vertex_data_;
-  std::string index_data_buffer_identifier_;
+  std::unique_ptr<Token> index_data_buffer_identifier_;
   size_t vertex_count_;
   Topology topology_;
-  std::unordered_map<size_t, std::string> framebuffer_attachments_;
+  std::unordered_map<size_t, std::unique_ptr<Token>> framebuffer_attachments_;
 };
 
 }  // namespace shadertrap

--- a/src/libshadertrap/include/libshadertrap/command_set_uniform.h
+++ b/src/libshadertrap/include/libshadertrap/command_set_uniform.h
@@ -28,13 +28,17 @@ namespace shadertrap {
 class CommandSetUniform : public Command {
  public:
   CommandSetUniform(std::unique_ptr<Token> start_token,
-                    std::string program_identifier, size_t location,
+                    std::unique_ptr<Token> program_identifier, size_t location,
                     UniformValue value);
 
   bool Accept(CommandVisitor* visitor) override;
 
   const std::string& GetProgramIdentifier() const {
-    return program_identifier_;
+    return program_identifier_->GetText();
+  }
+
+  const Token* GetProgramIdentifierToken() const {
+    return program_identifier_.get();
   }
 
   size_t GetLocation() const { return location_; }
@@ -42,7 +46,7 @@ class CommandSetUniform : public Command {
   const UniformValue& GetValue() const { return value_; }
 
  private:
-  std::string program_identifier_;
+  std::unique_ptr<Token> program_identifier_;
   size_t location_;
   UniformValue value_;
 };

--- a/src/libshadertrap/include/libshadertrap/vertex_attribute_info.h
+++ b/src/libshadertrap/include/libshadertrap/vertex_attribute_info.h
@@ -16,14 +16,26 @@
 #define LIBSHADERTRAP_VERTEX_ATTRIBUTE_INFO_H
 
 #include <cstddef>
+#include <memory>
 #include <string>
+
+#include "libshadertrap/token.h"
+
+namespace shadertrap {
 
 class VertexAttributeInfo {
  public:
-  VertexAttributeInfo(std::string buffer_identifier, size_t offset_bytes,
-                      size_t stride_bytes, size_t dimension);
+  VertexAttributeInfo(std::unique_ptr<Token> buffer_identifier,
+                      size_t offset_bytes, size_t stride_bytes,
+                      size_t dimension);
 
-  const std::string& GetBufferIdentifier() const { return buffer_identifier_; }
+  const std::string& GetBufferIdentifier() const {
+    return buffer_identifier_->GetText();
+  }
+
+  const Token* GetBufferIdentifierToken() const {
+    return buffer_identifier_.get();
+  }
 
   size_t GetOffsetBytes() const { return offset_bytes_; }
 
@@ -32,10 +44,12 @@ class VertexAttributeInfo {
   size_t GetDimension() const { return dimension_; }
 
  private:
-  std::string buffer_identifier_;
+  std::unique_ptr<Token> buffer_identifier_;
   size_t offset_bytes_;
   size_t stride_bytes_;
   size_t dimension_;
 };
+
+}  // namespace shadertrap
 
 #endif  // LIBSHADERTRAP_VERTEX_ATTRIBUTE_INFO_H

--- a/src/libshadertrap/src/checker.cc
+++ b/src/libshadertrap/src/checker.cc
@@ -156,28 +156,34 @@ bool Checker::VisitAssertPixels(CommandAssertPixels* command_assert_pixels) {
 
 bool Checker::VisitAssertSimilarEmdHistogram(
     CommandAssertSimilarEmdHistogram* command_assert_similar_emd_histogram) {
+  // TODO(afd): Both arguments must be renderbuffers
+  // TODO(afd): Both arguments must have the same dimensions
   (void)command_assert_similar_emd_histogram;
   return true;
 }
 
 bool Checker::VisitBindSampler(CommandBindSampler* command_bind_sampler) {
+  // TODO(afd): Check that the given sampler exists.
   (void)command_bind_sampler;
   return true;
 }
 
 bool Checker::VisitBindStorageBuffer(
     CommandBindStorageBuffer* command_bind_storage_buffer) {
+  // TODO(afd): Check that the given buffer exists.
   (void)command_bind_storage_buffer;
   return true;
 }
 
 bool Checker::VisitBindTexture(CommandBindTexture* command_bind_texture) {
+  // TODO(afd): Check that the given texture exists.
   (void)command_bind_texture;
   return true;
 }
 
 bool Checker::VisitBindUniformBuffer(
     CommandBindUniformBuffer* command_bind_uniform_buffer) {
+  // TODO(afd): Check that the given buffer exists.
   (void)command_bind_uniform_buffer;
   return true;
 }
@@ -398,6 +404,7 @@ bool Checker::VisitDeclareShader(CommandDeclareShader* declare_shader) {
 
 bool Checker::VisitDumpRenderbuffer(
     CommandDumpRenderbuffer* command_dump_renderbuffer) {
+  // TODO(afd): The given buffer must be a renderbuffer.
   (void)command_dump_renderbuffer;
   return true;
 }
@@ -417,11 +424,13 @@ bool Checker::VisitRunGraphics(CommandRunGraphics* command_run_graphics) {
 bool Checker::VisitSetSamplerOrTextureParameter(
     CommandSetSamplerOrTextureParameter*
         command_set_sampler_or_texture_parameter) {
+  // TODO(afd): The sampler or texture must exist.
   (void)command_set_sampler_or_texture_parameter;
   return true;
 }
 
 bool Checker::VisitSetUniform(CommandSetUniform* command_set_uniform) {
+  // TODO(afd): The program must exist. The uniform index must be valid.
   (void)command_set_uniform;
   return true;
 }

--- a/src/libshadertrap/src/checker.cc
+++ b/src/libshadertrap/src/checker.cc
@@ -14,6 +14,7 @@
 
 #include "libshadertrap/checker.h"
 
+#include <cassert>
 #include <cctype>
 #include <cstddef>
 #include <initializer_list>
@@ -21,6 +22,7 @@
 #include <utility>
 
 #include "libshadertrap/make_unique.h"
+#include "libshadertrap/vertex_attribute_info.h"
 
 namespace shadertrap {
 

--- a/src/libshadertrap/src/checker.cc
+++ b/src/libshadertrap/src/checker.cc
@@ -18,7 +18,7 @@
 #include <cctype>
 #include <cstddef>
 #include <initializer_list>
-#include <type_traits>
+#include <type_traits>  // IWYU pragma: keep
 #include <utility>
 
 #include "libshadertrap/make_unique.h"

--- a/src/libshadertrap/src/checker.cc
+++ b/src/libshadertrap/src/checker.cc
@@ -209,9 +209,16 @@ bool Checker::VisitAssertEqual(CommandAssertEqual* command_assert_equal) {
 }
 
 bool Checker::VisitAssertPixels(CommandAssertPixels* command_assert_pixels) {
-  // TODO(afd): first argument must be a renderbuffer
+  if (created_renderbuffers_.count(
+          command_assert_pixels->GetRenderbufferIdentifier()) == 0) {
+    message_consumer_->Message(
+        MessageConsumer::Severity::kError,
+        command_assert_pixels->GetRenderbufferIdentifierToken(),
+        "'" + command_assert_pixels->GetRenderbufferIdentifier() +
+            "' is not a renderbuffer");
+    return false;
+  }
   // TODO(afd): the rectangle must be in-bounds
-  (void)command_assert_pixels;
   return true;
 }
 

--- a/src/libshadertrap/src/checker.cc
+++ b/src/libshadertrap/src/checker.cc
@@ -269,28 +269,56 @@ bool Checker::VisitAssertSimilarEmdHistogram(
 }
 
 bool Checker::VisitBindSampler(CommandBindSampler* command_bind_sampler) {
-  // TODO(afd): Check that the given sampler exists.
-  (void)command_bind_sampler;
+  if (created_samplers_.count(command_bind_sampler->GetSamplerIdentifier()) ==
+      0) {
+    message_consumer_->Message(
+        MessageConsumer::Severity::kError,
+        command_bind_sampler->GetSamplerIdentifierToken(),
+        "'" + command_bind_sampler->GetSamplerIdentifier() +
+            "' must be a sampler");
+    return false;
+  }
   return true;
 }
 
 bool Checker::VisitBindStorageBuffer(
     CommandBindStorageBuffer* command_bind_storage_buffer) {
-  // TODO(afd): Check that the given buffer exists.
-  (void)command_bind_storage_buffer;
+  if (created_buffers_.count(
+          command_bind_storage_buffer->GetBufferIdentifier()) == 0) {
+    message_consumer_->Message(
+        MessageConsumer::Severity::kError,
+        command_bind_storage_buffer->GetBufferIdentifierToken(),
+        "'" + command_bind_storage_buffer->GetBufferIdentifier() +
+            "' must be a buffer");
+    return false;
+  }
   return true;
 }
 
 bool Checker::VisitBindTexture(CommandBindTexture* command_bind_texture) {
-  // TODO(afd): Check that the given texture exists.
-  (void)command_bind_texture;
+  if (created_textures_.count(command_bind_texture->GetTextureIdentifier()) ==
+      0) {
+    message_consumer_->Message(
+        MessageConsumer::Severity::kError,
+        command_bind_texture->GetTextureIdentifierToken(),
+        "'" + command_bind_texture->GetTextureIdentifier() +
+            "' must be a texture");
+    return false;
+  }
   return true;
 }
 
 bool Checker::VisitBindUniformBuffer(
     CommandBindUniformBuffer* command_bind_uniform_buffer) {
-  // TODO(afd): Check that the given buffer exists.
-  (void)command_bind_uniform_buffer;
+  if (created_buffers_.count(
+          command_bind_uniform_buffer->GetBufferIdentifier()) == 0) {
+    message_consumer_->Message(
+        MessageConsumer::Severity::kError,
+        command_bind_uniform_buffer->GetBufferIdentifierToken(),
+        "'" + command_bind_uniform_buffer->GetBufferIdentifier() +
+            "' must be a buffer");
+    return false;
+  }
   return true;
 }
 

--- a/src/libshadertrap/src/command_assert_equal.cc
+++ b/src/libshadertrap/src/command_assert_equal.cc
@@ -20,9 +20,10 @@
 
 namespace shadertrap {
 
-CommandAssertEqual::CommandAssertEqual(std::unique_ptr<Token> start_token,
-                                       std::string buffer_identifier_1,
-                                       std::string buffer_identifier_2)
+CommandAssertEqual::CommandAssertEqual(
+    std::unique_ptr<Token> start_token,
+    std::unique_ptr<Token> buffer_identifier_1,
+    std::unique_ptr<Token> buffer_identifier_2)
     : Command(std::move(start_token)),
       buffer_identifier_1_(std::move(buffer_identifier_1)),
       buffer_identifier_2_(std::move(buffer_identifier_2)) {}

--- a/src/libshadertrap/src/command_assert_pixels.cc
+++ b/src/libshadertrap/src/command_assert_pixels.cc
@@ -20,13 +20,11 @@
 
 namespace shadertrap {
 
-CommandAssertPixels::CommandAssertPixels(std::unique_ptr<Token> start_token,
-                                         uint8_t expected_r, uint8_t expected_g,
-                                         uint8_t expected_b, uint8_t expected_a,
-                                         std::string renderbuffer_identifier,
-                                         size_t rectangle_x, size_t rectangle_y,
-                                         size_t rectangle_width,
-                                         size_t rectangle_height)
+CommandAssertPixels::CommandAssertPixels(
+    std::unique_ptr<Token> start_token, uint8_t expected_r, uint8_t expected_g,
+    uint8_t expected_b, uint8_t expected_a,
+    std::unique_ptr<Token> renderbuffer_identifier, size_t rectangle_x,
+    size_t rectangle_y, size_t rectangle_width, size_t rectangle_height)
     : Command(std::move(start_token)),
       expected_r_(expected_r),
       expected_g_(expected_g),

--- a/src/libshadertrap/src/command_assert_pixels.cc
+++ b/src/libshadertrap/src/command_assert_pixels.cc
@@ -24,7 +24,9 @@ CommandAssertPixels::CommandAssertPixels(
     std::unique_ptr<Token> start_token, uint8_t expected_r, uint8_t expected_g,
     uint8_t expected_b, uint8_t expected_a,
     std::unique_ptr<Token> renderbuffer_identifier, size_t rectangle_x,
-    size_t rectangle_y, size_t rectangle_width, size_t rectangle_height)
+    size_t rectangle_y, size_t rectangle_width, size_t rectangle_height,
+    std::unique_ptr<Token> rectangle_width_token,
+    std::unique_ptr<Token> rectangle_height_token)
     : Command(std::move(start_token)),
       expected_r_(expected_r),
       expected_g_(expected_g),
@@ -34,7 +36,9 @@ CommandAssertPixels::CommandAssertPixels(
       rectangle_x_(rectangle_x),
       rectangle_y_(rectangle_y),
       rectangle_width_(rectangle_width),
-      rectangle_height_(rectangle_height) {}
+      rectangle_height_(rectangle_height),
+      rectangle_width_token_(std::move(rectangle_width_token)),
+      rectangle_height_token_(std::move(rectangle_height_token)) {}
 
 bool CommandAssertPixels::Accept(CommandVisitor* visitor) {
   return visitor->VisitAssertPixels(this);

--- a/src/libshadertrap/src/command_assert_similar_emd_histogram.cc
+++ b/src/libshadertrap/src/command_assert_similar_emd_histogram.cc
@@ -21,8 +21,9 @@
 namespace shadertrap {
 
 CommandAssertSimilarEmdHistogram::CommandAssertSimilarEmdHistogram(
-    std::unique_ptr<Token> start_token, std::string buffer_identifier_1,
-    std::string buffer_identifier_2, float tolerance)
+    std::unique_ptr<Token> start_token,
+    std::unique_ptr<Token> buffer_identifier_1,
+    std::unique_ptr<Token> buffer_identifier_2, float tolerance)
     : Command(std::move(start_token)),
       buffer_identifier_1_(std::move(buffer_identifier_1)),
       buffer_identifier_2_(std::move(buffer_identifier_2)),

--- a/src/libshadertrap/src/command_bind_sampler.cc
+++ b/src/libshadertrap/src/command_bind_sampler.cc
@@ -20,9 +20,9 @@
 
 namespace shadertrap {
 
-CommandBindSampler::CommandBindSampler(std::unique_ptr<Token> start_token,
-                                       std::string sampler_identifier,
-                                       size_t texture_unit)
+CommandBindSampler::CommandBindSampler(
+    std::unique_ptr<Token> start_token,
+    std::unique_ptr<Token> sampler_identifier, size_t texture_unit)
     : Command(std::move(start_token)),
       sampler_identifier_(std::move(sampler_identifier)),
       texture_unit_(texture_unit) {}

--- a/src/libshadertrap/src/command_bind_storage_buffer.cc
+++ b/src/libshadertrap/src/command_bind_storage_buffer.cc
@@ -21,10 +21,10 @@
 namespace shadertrap {
 
 CommandBindStorageBuffer::CommandBindStorageBuffer(
-    std::unique_ptr<Token> start_token, std::string storage_buffer_identifier,
-    size_t binding)
+    std::unique_ptr<Token> start_token,
+    std::unique_ptr<Token> buffer_identifier, size_t binding)
     : Command(std::move(start_token)),
-      storage_buffer_identifier_(std::move(storage_buffer_identifier)),
+      buffer_identifier_(std::move(buffer_identifier)),
       binding_(binding) {}
 
 bool CommandBindStorageBuffer::Accept(CommandVisitor* visitor) {

--- a/src/libshadertrap/src/command_bind_texture.cc
+++ b/src/libshadertrap/src/command_bind_texture.cc
@@ -20,9 +20,9 @@
 
 namespace shadertrap {
 
-CommandBindTexture::CommandBindTexture(std::unique_ptr<Token> start_token,
-                                       std::string texture_identifier,
-                                       size_t texture_unit)
+CommandBindTexture::CommandBindTexture(
+    std::unique_ptr<Token> start_token,
+    std::unique_ptr<Token> texture_identifier, size_t texture_unit)
     : Command(std::move(start_token)),
       texture_identifier_(std::move(texture_identifier)),
       texture_unit_(texture_unit) {}

--- a/src/libshadertrap/src/command_bind_uniform_buffer.cc
+++ b/src/libshadertrap/src/command_bind_uniform_buffer.cc
@@ -21,10 +21,10 @@
 namespace shadertrap {
 
 CommandBindUniformBuffer::CommandBindUniformBuffer(
-    std::unique_ptr<Token> start_token, std::string uniform_buffer_identifier,
-    size_t binding)
+    std::unique_ptr<Token> start_token,
+    std::unique_ptr<Token> buffer_identifier, size_t binding)
     : Command(std::move(start_token)),
-      uniform_buffer_identifier_(std::move(uniform_buffer_identifier)),
+      buffer_identifier_(std::move(buffer_identifier)),
       binding_(binding) {}
 
 bool CommandBindUniformBuffer::Accept(CommandVisitor* visitor) {

--- a/src/libshadertrap/src/command_create_renderbuffer.cc
+++ b/src/libshadertrap/src/command_create_renderbuffer.cc
@@ -21,8 +21,8 @@
 namespace shadertrap {
 
 CommandCreateRenderbuffer::CommandCreateRenderbuffer(
-    std::unique_ptr<Token> start_token, std::string result_identifier,
-    size_t width, size_t height)
+    std::unique_ptr<Token> start_token,
+    std::unique_ptr<Token> result_identifier, size_t width, size_t height)
     : Command(std::move(start_token)),
       result_identifier_(std::move(result_identifier)),
       width_(width),

--- a/src/libshadertrap/src/command_dump_renderbuffer.cc
+++ b/src/libshadertrap/src/command_dump_renderbuffer.cc
@@ -21,8 +21,8 @@
 namespace shadertrap {
 
 CommandDumpRenderbuffer::CommandDumpRenderbuffer(
-    std::unique_ptr<Token> start_token, std::string renderbuffer_identifier,
-    std::string filename)
+    std::unique_ptr<Token> start_token,
+    std::unique_ptr<Token> renderbuffer_identifier, std::string filename)
     : Command(std::move(start_token)),
       renderbuffer_identifier_(std::move(renderbuffer_identifier)),
       filename_(std::move(filename)) {}

--- a/src/libshadertrap/src/command_run_compute.cc
+++ b/src/libshadertrap/src/command_run_compute.cc
@@ -21,7 +21,7 @@
 namespace shadertrap {
 
 CommandRunCompute::CommandRunCompute(std::unique_ptr<Token> start_token,
-                                     std::string program_identifier,
+                                     std::unique_ptr<Token> program_identifier,
                                      size_t num_groups_x, size_t num_groups_y,
                                      size_t num_groups_z)
     : Command(std::move(start_token)),

--- a/src/libshadertrap/src/command_run_graphics.cc
+++ b/src/libshadertrap/src/command_run_graphics.cc
@@ -21,17 +21,19 @@
 namespace shadertrap {
 
 CommandRunGraphics::CommandRunGraphics(
-    std::unique_ptr<Token> start_token, std::string program_identifier,
+    std::unique_ptr<Token> start_token,
+    std::unique_ptr<Token> program_identifier,
     std::unordered_map<size_t, VertexAttributeInfo> vertex_data,
-    std::string index_data_buffer_identifier, size_t vertex_count,
-    Topology topology, std::unordered_map<size_t, std::string> output_buffers)
+    std::unique_ptr<Token> index_data_buffer_identifier, size_t vertex_count,
+    Topology topology,
+    std::unordered_map<size_t, std::unique_ptr<Token>> framebuffer_attachments)
     : Command(std::move(start_token)),
       program_identifier_(std::move(program_identifier)),
       vertex_data_(std::move(vertex_data)),
       index_data_buffer_identifier_(std::move(index_data_buffer_identifier)),
       vertex_count_(vertex_count),
       topology_(topology),
-      framebuffer_attachments_(std::move(output_buffers)) {}
+      framebuffer_attachments_(std::move(framebuffer_attachments)) {}
 
 bool CommandRunGraphics::Accept(CommandVisitor* visitor) {
   return visitor->VisitRunGraphics(this);

--- a/src/libshadertrap/src/command_set_uniform.cc
+++ b/src/libshadertrap/src/command_set_uniform.cc
@@ -21,7 +21,7 @@
 namespace shadertrap {
 
 CommandSetUniform::CommandSetUniform(std::unique_ptr<Token> start_token,
-                                     std::string program_identifier,
+                                     std::unique_ptr<Token> program_identifier,
                                      size_t location, UniformValue value)
     : Command(std::move(start_token)),
       program_identifier_(std::move(program_identifier)),

--- a/src/libshadertrap/src/executor.cc
+++ b/src/libshadertrap/src/executor.cc
@@ -265,10 +265,9 @@ bool Executor::VisitBindSampler(CommandBindSampler* bind_sampler) {
 
 bool Executor::VisitBindStorageBuffer(
     CommandBindStorageBuffer* bind_storage_buffer) {
-  GL_SAFECALL(
-      glBindBufferBase, GL_SHADER_STORAGE_BUFFER,
-      static_cast<GLuint>(bind_storage_buffer->GetBinding()),
-      created_buffers_.at(bind_storage_buffer->GetStorageBufferIdentifier()));
+  GL_SAFECALL(glBindBufferBase, GL_SHADER_STORAGE_BUFFER,
+              static_cast<GLuint>(bind_storage_buffer->GetBinding()),
+              created_buffers_.at(bind_storage_buffer->GetBufferIdentifier()));
   return true;
 }
 
@@ -283,10 +282,9 @@ bool Executor::VisitBindTexture(CommandBindTexture* bind_texture) {
 
 bool Executor::VisitBindUniformBuffer(
     CommandBindUniformBuffer* bind_uniform_buffer) {
-  GL_SAFECALL(
-      glBindBufferBase, GL_UNIFORM_BUFFER,
-      static_cast<GLuint>(bind_uniform_buffer->GetBinding()),
-      created_buffers_.at(bind_uniform_buffer->GetUniformBufferIdentifier()));
+  GL_SAFECALL(glBindBufferBase, GL_UNIFORM_BUFFER,
+              static_cast<GLuint>(bind_uniform_buffer->GetBinding()),
+              created_buffers_.at(bind_uniform_buffer->GetBufferIdentifier()));
   return true;
 }
 

--- a/src/libshadertrap/src/executor.cc
+++ b/src/libshadertrap/src/executor.cc
@@ -482,7 +482,7 @@ bool Executor::VisitRunCompute(CommandRunCompute* run_compute) {
 bool Executor::VisitRunGraphics(CommandRunGraphics* run_graphics) {
   GL_SAFECALL(glMemoryBarrier, GL_ALL_BARRIER_BITS);
 
-  auto vertex_data = run_graphics->GetVertexData();
+  const auto& vertex_data = run_graphics->GetVertexData();
   for (const auto& entry : vertex_data) {
     GL_SAFECALL(glBindBuffer, GL_ARRAY_BUFFER,
                 created_buffers_.at(entry.second.GetBufferIdentifier()));
@@ -500,7 +500,8 @@ bool Executor::VisitRunGraphics(CommandRunGraphics* run_graphics) {
   GL_SAFECALL(glGenFramebuffers, 1, &framebuffer_object_id);
   GL_SAFECALL(glBindFramebuffer, GL_FRAMEBUFFER, framebuffer_object_id);
 
-  auto framebuffer_attachments = run_graphics->GetFramebufferAttachments();
+  const auto& framebuffer_attachments =
+      run_graphics->GetFramebufferAttachments();
   assert(framebuffer_attachments.size() <= 32 && "Too many renderbuffers.");
   size_t max_location = 0;
   for (const auto& entry : framebuffer_attachments) {
@@ -510,14 +511,14 @@ bool Executor::VisitRunGraphics(CommandRunGraphics* run_graphics) {
   for (size_t i = 0; i <= max_location; i++) {
     if (framebuffer_attachments.count(i) > 0) {
       GLenum color_attachment = GL_COLOR_ATTACHMENT0 + static_cast<GLenum>(i);
-      auto output_buffer = framebuffer_attachments.at(i);
-      if (created_renderbuffers_.count(output_buffer) != 0) {
+      auto framebuffer_attachment = framebuffer_attachments.at(i)->GetText();
+      if (created_renderbuffers_.count(framebuffer_attachment) != 0) {
         GL_SAFECALL(glFramebufferRenderbuffer, GL_FRAMEBUFFER, color_attachment,
                     GL_RENDERBUFFER,
-                    created_renderbuffers_.at(framebuffer_attachments.at(i)));
+                    created_renderbuffers_.at(framebuffer_attachment));
       } else {
         GL_SAFECALL(glFramebufferTexture, GL_FRAMEBUFFER, color_attachment,
-                    created_textures_.at(framebuffer_attachments.at(i)), 0);
+                    created_textures_.at(framebuffer_attachment), 0);
       }
       draw_buffers.push_back(color_attachment);
     } else {

--- a/src/libshadertrap/src/executor.cc
+++ b/src/libshadertrap/src/executor.cc
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "libshadertrap/helpers.h"
+#include "libshadertrap/token.h"
 #include "libshadertrap/uniform_value.h"
 #include "libshadertrap/vertex_attribute_info.h"
 #include "lodepng/lodepng.h"

--- a/src/libshadertrap/src/parser.cc
+++ b/src/libshadertrap/src/parser.cc
@@ -111,8 +111,8 @@ bool Parser::ParseCommand() {
 
 bool Parser::ParseCommandAssertEqual() {
   auto start_token = tokenizer_->NextToken();
-  std::string buffer_identifier_1;
-  std::string buffer_identifier_2;
+  std::unique_ptr<Token> buffer_identifier_1;
+  std::unique_ptr<Token> buffer_identifier_2;
   if (!ParseParameters({{Token::Type::kKeywordBuffer1,
                          [this, &buffer_identifier_1]() -> bool {
                            auto token = tokenizer_->NextToken();
@@ -122,7 +122,7 @@ bool Parser::ParseCommandAssertEqual() {
                                  "Expected identifier for first renderbuffer "
                                  "to be compared");
                            }
-                           buffer_identifier_1 = token->GetText();
+                           buffer_identifier_1 = std::move(token);
                            return true;
                          }},
                         {Token::Type::kKeywordBuffer2,
@@ -134,13 +134,14 @@ bool Parser::ParseCommandAssertEqual() {
                                  "Expected identifier for second renderbuffer "
                                  "to be compared");
                            }
-                           buffer_identifier_2 = token->GetText();
+                           buffer_identifier_2 = std::move(token);
                            return true;
                          }}})) {
     return false;
   }
   parsed_commands_.push_back(MakeUnique<CommandAssertEqual>(
-      std::move(start_token), buffer_identifier_1, buffer_identifier_2));
+      std::move(start_token), std::move(buffer_identifier_1),
+      std::move(buffer_identifier_2)));
   return true;
 }
 
@@ -699,7 +700,7 @@ bool Parser::ParseCommandCreateRenderbuffer() {
     return false;
   }
   parsed_commands_.push_back(MakeUnique<CommandCreateRenderbuffer>(
-      std::move(start_token), result_identifier->GetText(), width, height));
+      std::move(start_token), std::move(result_identifier), width, height));
   return true;
 }
 

--- a/src/libshadertrap/src/parser.cc
+++ b/src/libshadertrap/src/parser.cc
@@ -151,7 +151,7 @@ bool Parser::ParseCommandAssertPixels() {
   uint8_t expected_g;
   uint8_t expected_b;
   uint8_t expected_a;
-  std::string renderbuffer_identifier;
+  std::unique_ptr<Token> renderbuffer_identifier;
   size_t rectangle_x;
   size_t rectangle_y;
   size_t rectangle_width;
@@ -190,7 +190,7 @@ bool Parser::ParseCommandAssertPixels() {
                                  "Expected renderbuffer identifier");
                              return false;
                            }
-                           renderbuffer_identifier = token->GetText();
+                           renderbuffer_identifier = std::move(token);
                            return true;
                          }},
                         {Token::Type::kKeywordRectangle,
@@ -222,8 +222,8 @@ bool Parser::ParseCommandAssertPixels() {
   }
   parsed_commands_.push_back(MakeUnique<CommandAssertPixels>(
       std::move(start_token), expected_r, expected_g, expected_b, expected_a,
-      renderbuffer_identifier, rectangle_x, rectangle_y, rectangle_width,
-      rectangle_height));
+      std::move(renderbuffer_identifier), rectangle_x, rectangle_y,
+      rectangle_width, rectangle_height));
   return true;
 }
 

--- a/src/libshadertrap/src/parser.cc
+++ b/src/libshadertrap/src/parser.cc
@@ -235,8 +235,8 @@ bool Parser::ParseCommandAssertPixels() {
 
 bool Parser::ParseCommandAssertSimilarEmdHistogram() {
   auto start_token = tokenizer_->NextToken();
-  std::string buffer_identifier_1;
-  std::string buffer_identifier_2;
+  std::unique_ptr<Token> buffer_identifier_1;
+  std::unique_ptr<Token> buffer_identifier_2;
   float tolerance;
   if (!ParseParameters(
           {{Token::Type::kKeywordBuffer1,
@@ -247,7 +247,7 @@ bool Parser::ParseCommandAssertSimilarEmdHistogram() {
                     MessageConsumer::Severity::kError, token.get(),
                     "Expected identifier for first buffer to be compared");
               }
-              buffer_identifier_1 = token->GetText();
+              buffer_identifier_1 = std::move(token);
               return true;
             }},
            {Token::Type::kKeywordBuffer2,
@@ -258,7 +258,7 @@ bool Parser::ParseCommandAssertSimilarEmdHistogram() {
                     MessageConsumer::Severity::kError, token.get(),
                     "Expected identifier for second buffer to be compared");
               }
-              buffer_identifier_2 = token->GetText();
+              buffer_identifier_2 = std::move(token);
               return true;
             }},
            {Token::Type::kKeywordTolerance, [this, &tolerance]() -> bool {
@@ -272,8 +272,8 @@ bool Parser::ParseCommandAssertSimilarEmdHistogram() {
     return false;
   }
   parsed_commands_.push_back(MakeUnique<CommandAssertSimilarEmdHistogram>(
-      std::move(start_token), buffer_identifier_1, buffer_identifier_2,
-      tolerance));
+      std::move(start_token), std::move(buffer_identifier_1),
+      std::move(buffer_identifier_2), tolerance));
   return true;
 }
 

--- a/src/libshadertrap/src/parser.cc
+++ b/src/libshadertrap/src/parser.cc
@@ -17,6 +17,7 @@
 #include <cassert>
 #include <set>
 #include <sstream>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 

--- a/src/libshadertrap/src/parser.cc
+++ b/src/libshadertrap/src/parser.cc
@@ -156,6 +156,8 @@ bool Parser::ParseCommandAssertPixels() {
   size_t rectangle_y;
   size_t rectangle_width;
   size_t rectangle_height;
+  std::unique_ptr<Token> rectangle_width_token;
+  std::unique_ptr<Token> rectangle_height_token;
   if (!ParseParameters({{Token::Type::kKeywordExpected,
                          [this, &expected_r, &expected_g, &expected_b,
                           &expected_a]() -> bool {
@@ -195,7 +197,8 @@ bool Parser::ParseCommandAssertPixels() {
                          }},
                         {Token::Type::kKeywordRectangle,
                          [this, &rectangle_x, &rectangle_y, &rectangle_width,
-                          &rectangle_height]() -> bool {
+                          &rectangle_height, &rectangle_width_token,
+                          &rectangle_height_token]() -> bool {
                            auto maybe_x = ParseUint32("x coordinate");
                            if (!maybe_x.first) {
                              return false;
@@ -206,11 +209,13 @@ bool Parser::ParseCommandAssertPixels() {
                              return false;
                            }
                            rectangle_y = maybe_y.second;
+                           rectangle_width_token = tokenizer_->PeekNextToken();
                            auto maybe_width = ParseUint32("width");
                            if (!maybe_width.first) {
                              return false;
                            }
                            rectangle_width = maybe_width.second;
+                           rectangle_height_token = tokenizer_->PeekNextToken();
                            auto maybe_height = ParseUint32("height");
                            if (!maybe_height.first) {
                              return false;
@@ -223,7 +228,8 @@ bool Parser::ParseCommandAssertPixels() {
   parsed_commands_.push_back(MakeUnique<CommandAssertPixels>(
       std::move(start_token), expected_r, expected_g, expected_b, expected_a,
       std::move(renderbuffer_identifier), rectangle_x, rectangle_y,
-      rectangle_width, rectangle_height));
+      rectangle_width, rectangle_height, std::move(rectangle_width_token),
+      std::move(rectangle_height_token)));
   return true;
 }
 

--- a/src/libshadertrap/src/parser.cc
+++ b/src/libshadertrap/src/parser.cc
@@ -1022,7 +1022,7 @@ bool Parser::ParseCommandDeclareShader() {
 
 bool Parser::ParseCommandDumpRenderbuffer() {
   auto start_token = tokenizer_->NextToken();
-  std::string renderbuffer_identifier;
+  std::unique_ptr<Token> renderbuffer_identifier;
   std::string filename;
   if (!ParseParameters(
           {{Token::Type::kKeywordRenderbuffer,
@@ -1035,7 +1035,7 @@ bool Parser::ParseCommandDumpRenderbuffer() {
                         token->GetText() + "'");
                 return false;
               }
-              renderbuffer_identifier = token->GetText();
+              renderbuffer_identifier = std::move(token);
               return true;
             }},
            {Token::Type::kKeywordFile, [this, &filename]() -> bool {
@@ -1054,7 +1054,7 @@ bool Parser::ParseCommandDumpRenderbuffer() {
     return false;
   }
   parsed_commands_.push_back(MakeUnique<CommandDumpRenderbuffer>(
-      std::move(start_token), renderbuffer_identifier, filename));
+      std::move(start_token), std::move(renderbuffer_identifier), filename));
   return true;
 }
 
@@ -1167,7 +1167,7 @@ bool Parser::ParseCommandSetTextureOrSamplerParameter() {
 
 bool Parser::ParseCommandSetUniform() {
   auto start_token = tokenizer_->NextToken();
-  std::string program_identifier;
+  std::unique_ptr<Token> program_identifier;
   size_t location;
   UniformValue::ElementType type;
   std::pair<bool, size_t> maybe_array_size;
@@ -1184,7 +1184,7 @@ bool Parser::ParseCommandSetUniform() {
                                                token->GetText() + "'");
                 return false;
               }
-              program_identifier = token->GetText();
+              program_identifier = std::move(token);
               return true;
             }},
            {Token::Type::kKeywordLocation,
@@ -1279,9 +1279,9 @@ bool Parser::ParseCommandSetUniform() {
   if (!maybe_uniform_value.first) {
     return false;
   }
-  parsed_commands_.push_back(
-      MakeUnique<CommandSetUniform>(std::move(start_token), program_identifier,
-                                    location, maybe_uniform_value.second));
+  parsed_commands_.push_back(MakeUnique<CommandSetUniform>(
+      std::move(start_token), std::move(program_identifier), location,
+      maybe_uniform_value.second));
   return true;
 }
 

--- a/src/libshadertrap/src/parser.cc
+++ b/src/libshadertrap/src/parser.cc
@@ -279,7 +279,7 @@ bool Parser::ParseCommandAssertSimilarEmdHistogram() {
 
 bool Parser::ParseCommandBindSampler() {
   auto start_token = tokenizer_->NextToken();
-  std::string sampler_identifier;
+  std::unique_ptr<Token> sampler_identifier;
   size_t texture_unit;
   if (!ParseParameters(
           {{Token::Type::kKeywordSampler,
@@ -292,7 +292,7 @@ bool Parser::ParseCommandBindSampler() {
                         token->GetText() + "'");
                 return false;
               }
-              sampler_identifier = token->GetText();
+              sampler_identifier = std::move(token);
               return true;
             }},
            {Token::Type::kKeywordTextureUnit, [this, &texture_unit]() -> bool {
@@ -306,13 +306,13 @@ bool Parser::ParseCommandBindSampler() {
     return false;
   }
   parsed_commands_.push_back(MakeUnique<CommandBindSampler>(
-      std::move(start_token), sampler_identifier, texture_unit));
+      std::move(start_token), std::move(sampler_identifier), texture_unit));
   return true;
 }
 
 bool Parser::ParseCommandBindStorageBuffer() {
   auto start_token = tokenizer_->NextToken();
-  std::string buffer_identifier;
+  std::unique_ptr<Token> buffer_identifier;
   size_t binding;
   if (!ParseParameters(
           {{Token::Type::kKeywordBuffer,
@@ -325,7 +325,7 @@ bool Parser::ParseCommandBindStorageBuffer() {
                         token->GetText() + "'");
                 return false;
               }
-              buffer_identifier = token->GetText();
+              buffer_identifier = std::move(token);
               return true;
             }},
            {Token::Type::kKeywordBinding, [this, &binding]() -> bool {
@@ -339,13 +339,13 @@ bool Parser::ParseCommandBindStorageBuffer() {
     return false;
   }
   parsed_commands_.push_back(MakeUnique<CommandBindStorageBuffer>(
-      std::move(start_token), buffer_identifier, binding));
+      std::move(start_token), std::move(buffer_identifier), binding));
   return true;
 }
 
 bool Parser::ParseCommandBindTexture() {
   auto start_token = tokenizer_->NextToken();
-  std::string texture_identifier;
+  std::unique_ptr<Token> texture_identifier;
   size_t texture_unit;
   if (!ParseParameters(
           {{Token::Type::kKeywordTexture,
@@ -358,7 +358,7 @@ bool Parser::ParseCommandBindTexture() {
                         token->GetText() + "'");
                 return false;
               }
-              texture_identifier = token->GetText();
+              texture_identifier = std::move(token);
               return true;
             }},
            {Token::Type::kKeywordTextureUnit, [this, &texture_unit]() -> bool {
@@ -372,13 +372,13 @@ bool Parser::ParseCommandBindTexture() {
     return false;
   }
   parsed_commands_.push_back(MakeUnique<CommandBindTexture>(
-      std::move(start_token), texture_identifier, texture_unit));
+      std::move(start_token), std::move(texture_identifier), texture_unit));
   return true;
 }
 
 bool Parser::ParseCommandBindUniformBuffer() {
   auto start_token = tokenizer_->NextToken();
-  std::string buffer_identifier;
+  std::unique_ptr<Token> buffer_identifier;
   size_t binding;
   if (!ParseParameters(
           {{Token::Type::kKeywordBuffer,
@@ -391,7 +391,7 @@ bool Parser::ParseCommandBindUniformBuffer() {
                         token->GetText() + "'");
                 return false;
               }
-              buffer_identifier = token->GetText();
+              buffer_identifier = std::move(token);
               return true;
             }},
            {Token::Type::kKeywordBinding, [this, &binding]() -> bool {
@@ -405,7 +405,7 @@ bool Parser::ParseCommandBindUniformBuffer() {
     return false;
   }
   parsed_commands_.push_back(MakeUnique<CommandBindUniformBuffer>(
-      std::move(start_token), buffer_identifier, binding));
+      std::move(start_token), std::move(buffer_identifier), binding));
   return true;
 }
 

--- a/src/libshadertrap/src/vertex_attribute_info.cc
+++ b/src/libshadertrap/src/vertex_attribute_info.cc
@@ -16,10 +16,14 @@
 
 #include <utility>
 
-VertexAttributeInfo::VertexAttributeInfo(std::string buffer_identifier,
-                                         size_t offset_bytes,
-                                         size_t stride_bytes, size_t dimension)
+namespace shadertrap {
+
+VertexAttributeInfo::VertexAttributeInfo(
+    std::unique_ptr<Token> buffer_identifier, size_t offset_bytes,
+    size_t stride_bytes, size_t dimension)
     : buffer_identifier_(std::move(buffer_identifier)),
       offset_bytes_(offset_bytes),
       stride_bytes_(stride_bytes),
       dimension_(dimension) {}
+
+}  // namespace shadertrap

--- a/src/libshadertraptest/src/checker_test.cc
+++ b/src/libshadertraptest/src/checker_test.cc
@@ -448,5 +448,25 @@ CREATE_EMPTY_TEXTURE_2D name WIDTH 12 HEIGHT 12
             message_consumer.GetMessageString(0));
 }
 
+TEST_F(CheckerTestFixture, AssertEqualDifferentSizedRenderbuffers) { FAIL(); }
+
+TEST_F(CheckerTestFixture, AssertEqualDifferentSizedBuffers) { FAIL(); }
+
+TEST_F(CheckerTestFixture, AssertEqualBufferVsRenderbuffer) { FAIL(); }
+
+TEST_F(CheckerTestFixture, AssertEqualBadFistArgument) { FAIL(); }
+
+TEST_F(CheckerTestFixture, AssertEqualBadSecondArgument) { FAIL(); }
+
+TEST_F(CheckerTestFixture, AssertPixelsNotRenderbuffer) { FAIL(); }
+
+TEST_F(CheckerTestFixture, AssertPixelsOutOfRangeX) { FAIL(); }
+
+TEST_F(CheckerTestFixture, AssertPixelsOutOfRangeY) { FAIL(); }
+
+TEST_F(CheckerTestFixture, TODO) { FAIL(); }
+
+TEST_F(CheckerTestFixture, TODO) { FAIL(); }
+
 }  // namespace
 }  // namespace shadertrap

--- a/src/libshadertraptest/src/checker_test.cc
+++ b/src/libshadertraptest/src/checker_test.cc
@@ -608,5 +608,73 @@ ASSERT_PIXELS RENDERBUFFER buf RECTANGLE 0 0 2 2 EXPECTED 0 0 0 0
             message_consumer.GetMessageString(0));
 }
 
+TEST_F(CheckerTestFixture, AssertPixelsOutOfBoundsX) {
+  std::string program =
+      R"(CREATE_RENDERBUFFER buf WIDTH 16 HEIGHT 16
+ASSERT_PIXELS RENDERBUFFER buf RECTANGLE 8 8 9 8 EXPECTED 0 0 0 0
+)";
+
+  CollectingMessageConsumer message_consumer;
+  Parser parser(program, &message_consumer);
+  ASSERT_TRUE(parser.Parse());
+  Checker checker(&message_consumer);
+  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  ASSERT_EQ(1, message_consumer.GetNumMessages());
+  ASSERT_EQ(
+      "ERROR: 2:46: rectangle extends to x-coordinate 17, which exceeds width "
+      "16 of 'buf'",
+      message_consumer.GetMessageString(0));
+}
+
+TEST_F(CheckerTestFixture, AssertPixelsOutOfBoundsY) {
+  std::string program =
+      R"(CREATE_RENDERBUFFER buf WIDTH 16 HEIGHT 16
+ASSERT_PIXELS RENDERBUFFER buf RECTANGLE 8 8 8 9 EXPECTED 0 0 0 0
+)";
+
+  CollectingMessageConsumer message_consumer;
+  Parser parser(program, &message_consumer);
+  ASSERT_TRUE(parser.Parse());
+  Checker checker(&message_consumer);
+  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  ASSERT_EQ(1, message_consumer.GetNumMessages());
+  ASSERT_EQ(
+      "ERROR: 2:48: rectangle extends to y-coordinate 17, which exceeds height "
+      "16 of 'buf'",
+      message_consumer.GetMessageString(0));
+}
+
+TEST_F(CheckerTestFixture, AssertPixelsZeroWidthRectangle) {
+  std::string program =
+      R"(CREATE_RENDERBUFFER buf WIDTH 16 HEIGHT 16
+ASSERT_PIXELS RENDERBUFFER buf RECTANGLE 8 8 0 8 EXPECTED 0 0 0 0
+)";
+
+  CollectingMessageConsumer message_consumer;
+  Parser parser(program, &message_consumer);
+  ASSERT_TRUE(parser.Parse());
+  Checker checker(&message_consumer);
+  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  ASSERT_EQ(1, message_consumer.GetNumMessages());
+  ASSERT_EQ("ERROR: 2:46: width of rectangle must be positive",
+            message_consumer.GetMessageString(0));
+}
+
+TEST_F(CheckerTestFixture, AssertPixelsZeroHeightRectangle) {
+  std::string program =
+      R"(CREATE_RENDERBUFFER buf WIDTH 16 HEIGHT 16
+ASSERT_PIXELS RENDERBUFFER buf RECTANGLE 8 8 8 0 EXPECTED 0 0 0 0
+)";
+
+  CollectingMessageConsumer message_consumer;
+  Parser parser(program, &message_consumer);
+  ASSERT_TRUE(parser.Parse());
+  Checker checker(&message_consumer);
+  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  ASSERT_EQ(1, message_consumer.GetNumMessages());
+  ASSERT_EQ("ERROR: 2:48: height of rectangle must be positive",
+            message_consumer.GetMessageString(0));
+}
+
 }  // namespace
 }  // namespace shadertrap

--- a/src/libshadertraptest/src/checker_test.cc
+++ b/src/libshadertraptest/src/checker_test.cc
@@ -798,5 +798,35 @@ TEST_F(CheckerTestFixture, BindUniformBufferBadUniformBuffer) {
             message_consumer.GetMessageString(0));
 }
 
+TEST_F(CheckerTestFixture, DumpRenderbufferBadRenderbuffer) {
+  std::string program =
+      R"(DUMP_RENDERBUFFER RENDERBUFFER doesnotexist FILE "temp.png"
+)";
+
+  CollectingMessageConsumer message_consumer;
+  Parser parser(program, &message_consumer);
+  ASSERT_TRUE(parser.Parse());
+  Checker checker(&message_consumer);
+  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  ASSERT_EQ(1, message_consumer.GetNumMessages());
+  ASSERT_EQ("ERROR: 1:32: 'doesnotexist' must be a renderbuffer",
+            message_consumer.GetMessageString(0));
+}
+
+TEST_F(CheckerTestFixture, SetUniformBadProgram) {
+  std::string program =
+      R"(SET_UNIFORM PROGRAM prog LOCATION 1 TYPE float VALUES 0.1
+)";
+
+  CollectingMessageConsumer message_consumer;
+  Parser parser(program, &message_consumer);
+  ASSERT_TRUE(parser.Parse());
+  Checker checker(&message_consumer);
+  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  ASSERT_EQ(1, message_consumer.GetNumMessages());
+  ASSERT_EQ("ERROR: 1:21: 'prog' must be a program",
+            message_consumer.GetMessageString(0));
+}
+
 }  // namespace
 }  // namespace shadertrap

--- a/src/libshadertraptest/src/checker_test.cc
+++ b/src/libshadertraptest/src/checker_test.cc
@@ -676,5 +676,71 @@ ASSERT_PIXELS RENDERBUFFER buf RECTANGLE 8 8 8 0 EXPECTED 0 0 0 0
             message_consumer.GetMessageString(0));
 }
 
+TEST_F(CheckerTestFixture, AssertSimilarEmdHistogramBadFistArgument) {
+  std::string program = R"(CREATE_RENDERBUFFER buf2 WIDTH 24 HEIGHT 24
+ASSERT_SIMILAR_EMD_HISTOGRAM BUFFER1 buf1 BUFFER2 buf2 TOLERANCE 1.0
+)";
+
+  CollectingMessageConsumer message_consumer;
+  Parser parser(program, &message_consumer);
+  ASSERT_TRUE(parser.Parse());
+  Checker checker(&message_consumer);
+  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  ASSERT_EQ(1, message_consumer.GetNumMessages());
+  ASSERT_EQ("ERROR: 2:38: 'buf1' must be a renderbuffer",
+            message_consumer.GetMessageString(0));
+}
+
+TEST_F(CheckerTestFixture, AssertSimilarEmdHistogramBadSecondArgument) {
+  std::string program = R"(CREATE_RENDERBUFFER buf1 WIDTH 24 HEIGHT 24
+ASSERT_SIMILAR_EMD_HISTOGRAM BUFFER1 buf1 BUFFER2 buf2 TOLERANCE 1.0
+)";
+
+  CollectingMessageConsumer message_consumer;
+  Parser parser(program, &message_consumer);
+  ASSERT_TRUE(parser.Parse());
+  Checker checker(&message_consumer);
+  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  ASSERT_EQ(1, message_consumer.GetNumMessages());
+  ASSERT_EQ("ERROR: 2:51: 'buf2' must be a renderbuffer",
+            message_consumer.GetMessageString(0));
+}
+
+TEST_F(CheckerTestFixture, AssertSimilarEmdHistogramDifferentWidths) {
+  std::string program = R"(CREATE_RENDERBUFFER buf1 WIDTH 24 HEIGHT 24
+CREATE_RENDERBUFFER buf2 WIDTH 20 HEIGHT 24
+ASSERT_SIMILAR_EMD_HISTOGRAM BUFFER1 buf1 BUFFER2 buf2 TOLERANCE 1.0
+)";
+
+  CollectingMessageConsumer message_consumer;
+  Parser parser(program, &message_consumer);
+  ASSERT_TRUE(parser.Parse());
+  Checker checker(&message_consumer);
+  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  ASSERT_EQ(1, message_consumer.GetNumMessages());
+  ASSERT_EQ(
+      "ERROR: 3:51: width 20 of 'buf2' does not match width 24 of 'buf1' at "
+      "3:38",
+      message_consumer.GetMessageString(0));
+}
+
+TEST_F(CheckerTestFixture, AssertSimilarEmdHistogramDifferentHeights) {
+  std::string program = R"(CREATE_RENDERBUFFER buf1 WIDTH 24 HEIGHT 24
+CREATE_RENDERBUFFER buf2 WIDTH 24 HEIGHT 28
+ASSERT_SIMILAR_EMD_HISTOGRAM BUFFER1 buf1 BUFFER2 buf2 TOLERANCE 1.0
+)";
+
+  CollectingMessageConsumer message_consumer;
+  Parser parser(program, &message_consumer);
+  ASSERT_TRUE(parser.Parse());
+  Checker checker(&message_consumer);
+  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  ASSERT_EQ(1, message_consumer.GetNumMessages());
+  ASSERT_EQ(
+      "ERROR: 3:51: height 28 of 'buf2' does not match height 24 of 'buf1' at "
+      "3:38",
+      message_consumer.GetMessageString(0));
+}
+
 }  // namespace
 }  // namespace shadertrap

--- a/src/libshadertraptest/src/checker_test.cc
+++ b/src/libshadertraptest/src/checker_test.cc
@@ -742,5 +742,61 @@ ASSERT_SIMILAR_EMD_HISTOGRAM BUFFER1 buf1 BUFFER2 buf2 TOLERANCE 1.0
       message_consumer.GetMessageString(0));
 }
 
+TEST_F(CheckerTestFixture, BindSamplerBadSampler) {
+  std::string program = R"(BIND_SAMPLER SAMPLER doesnotexist TEXTURE_UNIT 1
+)";
+
+  CollectingMessageConsumer message_consumer;
+  Parser parser(program, &message_consumer);
+  ASSERT_TRUE(parser.Parse());
+  Checker checker(&message_consumer);
+  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  ASSERT_EQ(1, message_consumer.GetNumMessages());
+  ASSERT_EQ("ERROR: 1:22: 'doesnotexist' must be a sampler",
+            message_consumer.GetMessageString(0));
+}
+
+TEST_F(CheckerTestFixture, BindStorageBufferBadStorageBuffer) {
+  std::string program = R"(BIND_STORAGE_BUFFER BUFFER doesnotexist BINDING 1
+)";
+
+  CollectingMessageConsumer message_consumer;
+  Parser parser(program, &message_consumer);
+  ASSERT_TRUE(parser.Parse());
+  Checker checker(&message_consumer);
+  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  ASSERT_EQ(1, message_consumer.GetNumMessages());
+  ASSERT_EQ("ERROR: 1:28: 'doesnotexist' must be a buffer",
+            message_consumer.GetMessageString(0));
+}
+
+TEST_F(CheckerTestFixture, BindTextureBadTexture) {
+  std::string program = R"(BIND_TEXTURE TEXTURE doesnotexist TEXTURE_UNIT 1
+)";
+
+  CollectingMessageConsumer message_consumer;
+  Parser parser(program, &message_consumer);
+  ASSERT_TRUE(parser.Parse());
+  Checker checker(&message_consumer);
+  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  ASSERT_EQ(1, message_consumer.GetNumMessages());
+  ASSERT_EQ("ERROR: 1:22: 'doesnotexist' must be a texture",
+            message_consumer.GetMessageString(0));
+}
+
+TEST_F(CheckerTestFixture, BindUniformBufferBadUniformBuffer) {
+  std::string program = R"(BIND_UNIFORM_BUFFER BUFFER doesnotexist BINDING 1
+)";
+
+  CollectingMessageConsumer message_consumer;
+  Parser parser(program, &message_consumer);
+  ASSERT_TRUE(parser.Parse());
+  Checker checker(&message_consumer);
+  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  ASSERT_EQ(1, message_consumer.GetNumMessages());
+  ASSERT_EQ("ERROR: 1:28: 'doesnotexist' must be a buffer",
+            message_consumer.GetMessageString(0));
+}
+
 }  // namespace
 }  // namespace shadertrap

--- a/src/libshadertraptest/src/checker_test.cc
+++ b/src/libshadertraptest/src/checker_test.cc
@@ -592,5 +592,21 @@ ASSERT_EQUAL BUFFER2 buf2 BUFFER1 buf1
       message_consumer.GetMessageString(0));
 }
 
+TEST_F(CheckerTestFixture, AssertPixelsNotRenderbuffer) {
+  std::string program =
+      R"(CREATE_BUFFER buf SIZE_BYTES 4 INIT_TYPE int INIT_VALUES 0
+ASSERT_PIXELS RENDERBUFFER buf RECTANGLE 0 0 2 2 EXPECTED 0 0 0 0
+)";
+
+  CollectingMessageConsumer message_consumer;
+  Parser parser(program, &message_consumer);
+  ASSERT_TRUE(parser.Parse());
+  Checker checker(&message_consumer);
+  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  ASSERT_EQ(1, message_consumer.GetNumMessages());
+  ASSERT_EQ("ERROR: 2:28: 'buf' is not a renderbuffer",
+            message_consumer.GetMessageString(0));
+}
+
 }  // namespace
 }  // namespace shadertrap


### PR DESCRIPTION
This adds various checks to help ensure that a ShaderTrap program is
well-formed before executing it, such as checking that samplers and
textures exist when setting their parameters, that uniforms exist
before setting their values, etc.