### PR TITLE
Prefer const references over const pointers

### DIFF
--- a/src/libshadertrap/include/libshadertrap/checker.h
+++ b/src/libshadertrap/include/libshadertrap/checker.h
@@ -99,7 +99,7 @@ class Checker : public CommandVisitor {
 
   bool VisitSetUniform(CommandSetUniform* set_uniform) override;
 
-  bool CheckIdentifierIsFresh(const Token* identifier_token);
+  bool CheckIdentifierIsFresh(const Token& identifier_token);
 
  private:
   // |glslang_output| is output from glslang, which may contain error messages
@@ -117,7 +117,7 @@ class Checker : public CommandVisitor {
                                         const Token& renderbuffer_token_2);
 
   MessageConsumer* message_consumer_;
-  std::unordered_map<std::string, const Token*> used_identifiers_;
+  std::unordered_map<std::string, const Token&> used_identifiers_;
   std::unordered_map<std::string, CommandDeclareShader*> declared_shaders_;
   std::unordered_map<std::string, CommandCompileShader*> compiled_shaders_;
   std::unordered_map<std::string, CommandCreateProgram*> created_programs_;

--- a/src/libshadertrap/include/libshadertrap/command.h
+++ b/src/libshadertrap/include/libshadertrap/command.h
@@ -39,7 +39,7 @@ class Command {
 
   virtual bool Accept(CommandVisitor* visitor) = 0;
 
-  const Token* GetStartToken() const { return start_token_.get(); }
+  const Token& GetStartToken() const { return *start_token_; }
 
  private:
   std::unique_ptr<Token> start_token_;

--- a/src/libshadertrap/include/libshadertrap/command_assert_equal.h
+++ b/src/libshadertrap/include/libshadertrap/command_assert_equal.h
@@ -35,16 +35,16 @@ class CommandAssertEqual : public Command {
     return buffer_identifier_1_->GetText();
   }
 
-  const Token* GetBufferIdentifier1Token() const {
-    return buffer_identifier_1_.get();
+  const Token& GetBufferIdentifier1Token() const {
+    return *buffer_identifier_1_;
   }
 
   const std::string& GetBufferIdentifier2() const {
     return buffer_identifier_2_->GetText();
   }
 
-  const Token* GetBufferIdentifier2Token() const {
-    return buffer_identifier_2_.get();
+  const Token& GetBufferIdentifier2Token() const {
+    return *buffer_identifier_2_;
   }
 
  private:

--- a/src/libshadertrap/include/libshadertrap/command_assert_pixels.h
+++ b/src/libshadertrap/include/libshadertrap/command_assert_pixels.h
@@ -50,8 +50,8 @@ class CommandAssertPixels : public Command {
     return renderbuffer_identifier_->GetText();
   }
 
-  const Token* GetRenderbufferIdentifierToken() const {
-    return renderbuffer_identifier_.get();
+  const Token& GetRenderbufferIdentifierToken() const {
+    return *renderbuffer_identifier_;
   }
 
   size_t GetRectangleX() const { return rectangle_x_; }
@@ -62,12 +62,12 @@ class CommandAssertPixels : public Command {
 
   size_t GetRectangleHeight() const { return rectangle_height_; }
 
-  const Token* GetRectangleWidthToken() const {
-    return rectangle_width_token_.get();
+  const Token& GetRectangleWidthToken() const {
+    return *rectangle_width_token_;
   }
 
-  const Token* GetRectangleHeightToken() const {
-    return rectangle_height_token_.get();
+  const Token& GetRectangleHeightToken() const {
+    return *rectangle_height_token_;
   }
 
  private:

--- a/src/libshadertrap/include/libshadertrap/command_assert_similar_emd_histogram.h
+++ b/src/libshadertrap/include/libshadertrap/command_assert_similar_emd_histogram.h
@@ -36,16 +36,16 @@ class CommandAssertSimilarEmdHistogram : public Command {
     return buffer_identifier_1_->GetText();
   }
 
-  const Token* GetBufferIdentifier1Token() const {
-    return buffer_identifier_1_.get();
+  const Token& GetBufferIdentifier1Token() const {
+    return *buffer_identifier_1_;
   }
 
   const std::string& GetBufferIdentifier2() const {
     return buffer_identifier_2_->GetText();
   }
 
-  const Token* GetBufferIdentifier2Token() const {
-    return buffer_identifier_2_.get();
+  const Token& GetBufferIdentifier2Token() const {
+    return *buffer_identifier_2_;
   }
 
   float GetTolerance() const { return tolerance_; }

--- a/src/libshadertrap/include/libshadertrap/command_bind_sampler.h
+++ b/src/libshadertrap/include/libshadertrap/command_bind_sampler.h
@@ -36,8 +36,8 @@ class CommandBindSampler : public Command {
     return sampler_identifier_->GetText();
   }
 
-  const Token* GetSamplerIdentifierToken() const {
-    return sampler_identifier_.get();
+  const Token& GetSamplerIdentifierToken() const {
+    return *sampler_identifier_;
   }
 
   size_t GetTextureUnit() const { return texture_unit_; }

--- a/src/libshadertrap/include/libshadertrap/command_bind_storage_buffer.h
+++ b/src/libshadertrap/include/libshadertrap/command_bind_storage_buffer.h
@@ -36,9 +36,7 @@ class CommandBindStorageBuffer : public Command {
     return buffer_identifier_->GetText();
   }
 
-  const Token* GetBufferIdentifierToken() const {
-    return buffer_identifier_.get();
-  }
+  const Token& GetBufferIdentifierToken() const { return *buffer_identifier_; }
 
   size_t GetBinding() const { return binding_; }
 

--- a/src/libshadertrap/include/libshadertrap/command_bind_texture.h
+++ b/src/libshadertrap/include/libshadertrap/command_bind_texture.h
@@ -36,8 +36,8 @@ class CommandBindTexture : public Command {
     return texture_identifier_->GetText();
   }
 
-  const Token* GetTextureIdentifierToken() const {
-    return texture_identifier_.get();
+  const Token& GetTextureIdentifierToken() const {
+    return *texture_identifier_;
   }
 
   size_t GetTextureUnit() const { return texture_unit_; }

--- a/src/libshadertrap/include/libshadertrap/command_bind_uniform_buffer.h
+++ b/src/libshadertrap/include/libshadertrap/command_bind_uniform_buffer.h
@@ -36,9 +36,7 @@ class CommandBindUniformBuffer : public Command {
     return buffer_identifier_->GetText();
   }
 
-  const Token* GetBufferIdentifierToken() const {
-    return buffer_identifier_.get();
-  }
+  const Token& GetBufferIdentifierToken() const { return *buffer_identifier_; }
 
   size_t GetBinding() const { return binding_; }
 

--- a/src/libshadertrap/include/libshadertrap/command_compile_shader.h
+++ b/src/libshadertrap/include/libshadertrap/command_compile_shader.h
@@ -35,17 +35,13 @@ class CommandCompileShader : public Command {
     return result_identifier_->GetText();
   }
 
-  const Token* GetResultIdentifierToken() const {
-    return result_identifier_.get();
-  }
+  const Token& GetResultIdentifierToken() const { return *result_identifier_; }
 
   const std::string& GetShaderIdentifier() const {
     return shader_identifier_->GetText();
   }
 
-  const Token* GetShaderIdentifierToken() const {
-    return shader_identifier_.get();
-  }
+  const Token& GetShaderIdentifierToken() const { return *shader_identifier_; }
 
  private:
   std::unique_ptr<Token> result_identifier_;

--- a/src/libshadertrap/include/libshadertrap/command_create_buffer.h
+++ b/src/libshadertrap/include/libshadertrap/command_create_buffer.h
@@ -53,9 +53,7 @@ class CommandCreateBuffer : public Command {
     return result_identifier_->GetText();
   }
 
-  const Token* GetResultIdentifierToken() const {
-    return result_identifier_.get();
-  }
+  const Token& GetResultIdentifierToken() const { return *result_identifier_; }
 
   size_t GetSizeBytes() const { return size_bytes_; }
 

--- a/src/libshadertrap/include/libshadertrap/command_create_empty_texture_2d.h
+++ b/src/libshadertrap/include/libshadertrap/command_create_empty_texture_2d.h
@@ -36,9 +36,7 @@ class CommandCreateEmptyTexture2D : public Command {
     return result_identifier_->GetText();
   }
 
-  const Token* GetResultIdentifierToken() const {
-    return result_identifier_.get();
-  }
+  const Token& GetResultIdentifierToken() const { return *result_identifier_; }
 
   size_t GetWidth() const { return width_; }
 

--- a/src/libshadertrap/include/libshadertrap/command_create_program.h
+++ b/src/libshadertrap/include/libshadertrap/command_create_program.h
@@ -39,18 +39,16 @@ class CommandCreateProgram : public Command {
     return result_identifier_->GetText();
   }
 
-  const Token* GetResultIdentifierToken() const {
-    return result_identifier_.get();
-  }
+  const Token& GetResultIdentifierToken() const { return *result_identifier_; }
 
   const std::string& GetCompiledShaderIdentifier(size_t index) const {
-    return GetCompiledShaderIdentifierToken(index)->GetText();
+    return GetCompiledShaderIdentifierToken(index).GetText();
   }
 
-  const Token* GetCompiledShaderIdentifierToken(size_t index) const {
+  const Token& GetCompiledShaderIdentifierToken(size_t index) const {
     assert(index < compiled_shader_identifiers_.size() &&
            "Index out of bounds.");
-    return compiled_shader_identifiers_.at(index).get();
+    return *compiled_shader_identifiers_.at(index);
   }
 
   size_t GetNumCompiledShaders() const {

--- a/src/libshadertrap/include/libshadertrap/command_create_renderbuffer.h
+++ b/src/libshadertrap/include/libshadertrap/command_create_renderbuffer.h
@@ -40,9 +40,7 @@ class CommandCreateRenderbuffer : public Command {
     return result_identifier_->GetText();
   }
 
-  const Token* GetResultIdentifierToken() const {
-    return result_identifier_.get();
-  }
+  const Token& GetResultIdentifierToken() const { return *result_identifier_; }
 
  private:
   std::unique_ptr<Token> result_identifier_;

--- a/src/libshadertrap/include/libshadertrap/command_create_sampler.h
+++ b/src/libshadertrap/include/libshadertrap/command_create_sampler.h
@@ -34,9 +34,7 @@ class CommandCreateSampler : public Command {
     return result_identifier_->GetText();
   }
 
-  const Token* GetResultIdentifierToken() const {
-    return result_identifier_.get();
-  }
+  const Token& GetResultIdentifierToken() const { return *result_identifier_; }
 
  private:
   std::unique_ptr<Token> result_identifier_;

--- a/src/libshadertrap/include/libshadertrap/command_declare_shader.h
+++ b/src/libshadertrap/include/libshadertrap/command_declare_shader.h
@@ -38,9 +38,7 @@ class CommandDeclareShader : public Command {
     return result_identifier_->GetText();
   }
 
-  const Token* GetResultIdentifierToken() const {
-    return result_identifier_.get();
-  }
+  const Token& GetResultIdentifierToken() const { return *result_identifier_; }
 
   const std::string& GetShaderText() const { return shader_text_; }
 

--- a/src/libshadertrap/include/libshadertrap/command_dump_renderbuffer.h
+++ b/src/libshadertrap/include/libshadertrap/command_dump_renderbuffer.h
@@ -35,8 +35,8 @@ class CommandDumpRenderbuffer : public Command {
     return renderbuffer_identifier_->GetText();
   }
 
-  const Token* GetRenderbufferIdentifierToken() const {
-    return renderbuffer_identifier_.get();
+  const Token& GetRenderbufferIdentifierToken() const {
+    return *renderbuffer_identifier_;
   }
 
   const std::string& GetFilename() const { return filename_; }

--- a/src/libshadertrap/include/libshadertrap/command_run_compute.h
+++ b/src/libshadertrap/include/libshadertrap/command_run_compute.h
@@ -39,8 +39,8 @@ class CommandRunCompute : public Command {
     return program_identifier_->GetText();
   }
 
-  const Token* GetProgramIdentifierToken() const {
-    return program_identifier_.get();
+  const Token& GetProgramIdentifierToken() const {
+    return *program_identifier_;
   }
 
   size_t GetNumGroupsX() const { return num_groups_x_; }

--- a/src/libshadertrap/include/libshadertrap/command_run_graphics.h
+++ b/src/libshadertrap/include/libshadertrap/command_run_graphics.h
@@ -45,8 +45,8 @@ class CommandRunGraphics : public Command {
     return program_identifier_->GetText();
   }
 
-  const Token* GetProgramIdentifierToken() const {
-    return program_identifier_.get();
+  const Token& GetProgramIdentifierToken() const {
+    return *program_identifier_;
   }
 
   const std::unordered_map<size_t, VertexAttributeInfo>& GetVertexData() const {
@@ -57,8 +57,8 @@ class CommandRunGraphics : public Command {
     return index_data_buffer_identifier_->GetText();
   }
 
-  const Token* GetIndexDataBufferIdentifierToken() const {
-    return index_data_buffer_identifier_.get();
+  const Token& GetIndexDataBufferIdentifierToken() const {
+    return *index_data_buffer_identifier_;
   }
 
   size_t GetVertexCount() const { return vertex_count_; }

--- a/src/libshadertrap/include/libshadertrap/command_set_sampler_parameter.h
+++ b/src/libshadertrap/include/libshadertrap/command_set_sampler_parameter.h
@@ -37,8 +37,8 @@ class CommandSetSamplerParameter : public Command {
     return sampler_identifier_->GetText();
   }
 
-  const Token* GetSamplerIdentifierToken() const {
-    return sampler_identifier_.get();
+  const Token& GetSamplerIdentifierToken() const {
+    return *sampler_identifier_;
   }
 
   TextureParameter GetParameter() const { return parameter_; }

--- a/src/libshadertrap/include/libshadertrap/command_set_texture_parameter.h
+++ b/src/libshadertrap/include/libshadertrap/command_set_texture_parameter.h
@@ -37,8 +37,8 @@ class CommandSetTextureParameter : public Command {
     return texture_identifier_->GetText();
   }
 
-  const Token* GetTextureIdentifierToken() const {
-    return texture_identifier_.get();
+  const Token& GetTextureIdentifierToken() const {
+    return *texture_identifier_;
   }
 
   TextureParameter GetParameter() const { return parameter_; }

--- a/src/libshadertrap/include/libshadertrap/command_set_uniform.h
+++ b/src/libshadertrap/include/libshadertrap/command_set_uniform.h
@@ -37,8 +37,8 @@ class CommandSetUniform : public Command {
     return program_identifier_->GetText();
   }
 
-  const Token* GetProgramIdentifierToken() const {
-    return program_identifier_.get();
+  const Token& GetProgramIdentifierToken() const {
+    return *program_identifier_;
   }
 
   size_t GetLocation() const { return location_; }

--- a/src/libshadertrap/include/libshadertrap/vertex_attribute_info.h
+++ b/src/libshadertrap/include/libshadertrap/vertex_attribute_info.h
@@ -33,9 +33,7 @@ class VertexAttributeInfo {
     return buffer_identifier_->GetText();
   }
 
-  const Token* GetBufferIdentifierToken() const {
-    return buffer_identifier_.get();
-  }
+  const Token& GetBufferIdentifierToken() const { return *buffer_identifier_; }
 
   size_t GetOffsetBytes() const { return offset_bytes_; }
 

--- a/src/libshadertrap/src/executor.cc
+++ b/src/libshadertrap/src/executor.cc
@@ -114,7 +114,7 @@ bool Executor::VisitAssertPixels(CommandAssertPixels* assert_pixels) {
                      << assert_pixels->GetRenderbufferIdentifier() << "[" << x
                      << "][" << y << "]";
         message_consumer_->Message(MessageConsumer::Severity::kError,
-                                   assert_pixels->GetStartToken(),
+                                   &assert_pixels->GetStartToken(),
                                    stringstream.str());
       }
     }
@@ -157,7 +157,7 @@ bool Executor::VisitAssertSimilarEmdHistogram(
                  << assert_similar_emd_histogram->GetBufferIdentifier2()
                  << " do not match: " << width[0] << " vs. " << width[1];
     message_consumer_->Message(MessageConsumer::Severity::kError,
-                               assert_similar_emd_histogram->GetStartToken(),
+                               &assert_similar_emd_histogram->GetStartToken(),
                                stringstream.str());
     return false;
   }
@@ -170,7 +170,7 @@ bool Executor::VisitAssertSimilarEmdHistogram(
                  << assert_similar_emd_histogram->GetBufferIdentifier2()
                  << " do not match: " << height[0] << " vs. " << height[1];
     message_consumer_->Message(MessageConsumer::Severity::kError,
-                               assert_similar_emd_histogram->GetStartToken(),
+                               &assert_similar_emd_histogram->GetStartToken(),
                                stringstream.str());
     return false;
   }
@@ -250,7 +250,7 @@ bool Executor::VisitAssertSimilarEmdHistogram(
       static_cast<double>(assert_similar_emd_histogram->GetTolerance())) {
     message_consumer_->Message(
         MessageConsumer::Severity::kError,
-        assert_similar_emd_histogram->GetStartToken(),
+        &assert_similar_emd_histogram->GetStartToken(),
         "Histogram EMD value of " + std::to_string(max_emd) +
             " is greater than tolerance of " +
             std::to_string(assert_similar_emd_histogram->GetTolerance()));
@@ -731,7 +731,7 @@ bool Executor::CheckEqualRenderbuffers(CommandAssertEqual* assert_equal) {
                  << " and " << assert_equal->GetBufferIdentifier2()
                  << " do not match: " << width[0] << " vs. " << width[1];
     message_consumer_->Message(MessageConsumer::Severity::kError,
-                               assert_equal->GetStartToken(),
+                               &assert_equal->GetStartToken(),
                                stringstream.str());
     return false;
   }
@@ -742,7 +742,7 @@ bool Executor::CheckEqualRenderbuffers(CommandAssertEqual* assert_equal) {
                  << " and " << assert_equal->GetBufferIdentifier2()
                  << " do not match: " << height[0] << " vs. " << height[1];
     message_consumer_->Message(MessageConsumer::Severity::kError,
-                               assert_equal->GetStartToken(),
+                               &assert_equal->GetStartToken(),
                                stringstream.str());
     return false;
   }
@@ -802,7 +802,7 @@ bool Executor::CheckEqualRenderbuffers(CommandAssertEqual* assert_equal) {
                      << ", " << static_cast<uint32_t>(data[1][offset + 3])
                      << ")";
         message_consumer_->Message(MessageConsumer::Severity::kError,
-                                   assert_equal->GetStartToken(),
+                                   &assert_equal->GetStartToken(),
                                    stringstream.str());
         result = false;
       }
@@ -835,7 +835,7 @@ bool Executor::CheckEqualBuffers(CommandAssertEqual* assert_equal) {
                  << " do not match: " << buffer_size[0] << " vs. "
                  << buffer_size[1];
     message_consumer_->Message(MessageConsumer::Severity::kError,
-                               assert_equal->GetStartToken(),
+                               &assert_equal->GetStartToken(),
                                stringstream.str());
     return false;
   }
@@ -870,7 +870,7 @@ bool Executor::CheckEqualBuffers(CommandAssertEqual* assert_equal) {
                    << assert_equal->GetBufferIdentifier2() << "[" << index
                    << "] == " << static_cast<uint32_t>(value_2);
       message_consumer_->Message(MessageConsumer::Severity::kError,
-                                 assert_equal->GetStartToken(),
+                                 &assert_equal->GetStartToken(),
                                  stringstream.str());
       result = false;
     }


### PR DESCRIPTION
Changes many instances of 'const Token*' to 'const Token&'.