### PR TITLE
Add KIND parameter to DECLARE_SHADER

### DIFF
--- a/examples/cube.shadertrap
+++ b/examples/cube.shadertrap
@@ -17,7 +17,7 @@ CREATE_EMPTY_TEXTURE_2D my_tex WIDTH 256 HEIGHT 256
 SET_TEXTURE_PARAMETER TEXTURE my_tex PARAMETER TEXTURE_MAG_FILTER VALUE NEAREST
 SET_TEXTURE_PARAMETER TEXTURE my_tex PARAMETER TEXTURE_MIN_FILTER VALUE NEAREST
 
-DECLARE_SHADER texgen_frag FRAGMENT
+DECLARE_SHADER texgen_frag KIND FRAGMENT
 #version 320 es
 precision highp float;
 
@@ -32,7 +32,7 @@ void main()
 }
 END
 
-DECLARE_SHADER texgen_vert VERTEX
+DECLARE_SHADER texgen_vert KIND VERTEX
 #version 320 es
 layout(location = 0) in vec2 _GLF_vertexPosition;
 void main(void) {
@@ -40,7 +40,7 @@ void main(void) {
 }
 END
 
-DECLARE_SHADER cube_frag FRAGMENT
+DECLARE_SHADER cube_frag KIND FRAGMENT
 #version 320 es
 
 precision highp float;
@@ -56,7 +56,7 @@ void main() {
 }
 END
 
-DECLARE_SHADER cube_vert VERTEX
+DECLARE_SHADER cube_vert KIND VERTEX
 #version 320 es
 
 layout(location = 0) in vec3 a_position;

--- a/examples/flag.shadertrap
+++ b/examples/flag.shadertrap
@@ -14,7 +14,7 @@
 
 CREATE_EMPTY_TEXTURE_2D my_tex WIDTH 256 HEIGHT 256
 
-DECLARE_SHADER frag FRAGMENT
+DECLARE_SHADER frag KIND FRAGMENT
 #version 320 es
 
 precision highp float;
@@ -55,7 +55,7 @@ void main() {
 }
 END
 
-DECLARE_SHADER vert VERTEX
+DECLARE_SHADER vert KIND VERTEX
 #version 320 es
 layout(location = 0) in vec2 _GLF_vertexPosition;
 void main(void) {

--- a/examples/redtriangle.shadertrap
+++ b/examples/redtriangle.shadertrap
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DECLARE_SHADER frag FRAGMENT
+DECLARE_SHADER frag KIND FRAGMENT
 #version 320 es
 precision highp float;
 layout(location = 0) out vec4 color;
@@ -21,7 +21,7 @@ void main() {
 }
 END
 
-DECLARE_SHADER vert VERTEX
+DECLARE_SHADER vert KIND VERTEX
 #version 320 es
 layout(location = 0) in vec2 pos;
 void main(void) {

--- a/examples/rendertotexture.shadertrap
+++ b/examples/rendertotexture.shadertrap
@@ -20,7 +20,7 @@ SET_TEXTURE_PARAMETER TEXTURE my_tex PARAMETER TEXTURE_MAG_FILTER VALUE NEAREST
 
 SET_SAMPLER_PARAMETER SAMPLER my_sampler PARAMETER TEXTURE_MIN_FILTER VALUE NEAREST
 
-DECLARE_SHADER texgen_frag FRAGMENT
+DECLARE_SHADER texgen_frag KIND FRAGMENT
 #version 320 es
 precision highp float;
 
@@ -35,7 +35,7 @@ void main()
 }
 END
 
-DECLARE_SHADER vertex_shader VERTEX
+DECLARE_SHADER vertex_shader KIND VERTEX
 #version 320 es
 layout(location = 0) in vec2 _GLF_vertexPosition;
 void main(void) {
@@ -43,7 +43,7 @@ void main(void) {
 }
 END
 
-DECLARE_SHADER fragment_shader FRAGMENT
+DECLARE_SHADER fragment_shader KIND FRAGMENT
 #version 320 es
 
 precision highp float;

--- a/examples/simplecompute.shadertrap
+++ b/examples/simplecompute.shadertrap
@@ -18,7 +18,7 @@ CREATE_BUFFER expected SIZE_BYTES 4 INIT_VALUES uint 42
 
 BIND_SHADER_STORAGE_BUFFER BUFFER ssbo BINDING 0
 
-DECLARE_SHADER shader COMPUTE
+DECLARE_SHADER shader KIND COMPUTE
 #version 320 es
 
 layout(local_size_x=1, local_size_y=1, local_size_z=1) in;

--- a/examples/simplecompute_with_named_uniform.shadertrap
+++ b/examples/simplecompute_with_named_uniform.shadertrap
@@ -18,7 +18,7 @@ CREATE_BUFFER expected SIZE_BYTES 4 INIT_VALUES uint 42
 
 BIND_SHADER_STORAGE_BUFFER BUFFER ssbo BINDING 0
 
-DECLARE_SHADER shader COMPUTE
+DECLARE_SHADER shader KIND COMPUTE
 #version 320 es
 
 layout(local_size_x=1, local_size_y=1, local_size_z=1) in;

--- a/src/libshadertrap/include/libshadertrap/token.h
+++ b/src/libshadertrap/include/libshadertrap/token.h
@@ -59,6 +59,7 @@ class Token {
     kKeywordIndexData,
     kKeywordInitType,
     kKeywordInitValues,
+    kKeywordKind,
     kKeywordLinear,
     kKeywordLocation,
     kKeywordName,

--- a/src/libshadertrap/src/parser.cc
+++ b/src/libshadertrap/src/parser.cc
@@ -873,6 +873,17 @@ bool Parser::ParseCommandDeclareShader() {
             result_identifier->GetText() + "'");
     return false;
   }
+
+  auto kind_keyword = tokenizer_->NextToken();
+  if (kind_keyword->GetType() != Token::Type::kKeywordKind) {
+    message_consumer_->Message(MessageConsumer::Severity::kError,
+                               kind_keyword.get(),
+                               "Missing parameter 'KIND' to specify which kind "
+                               "of shader this is, got '" +
+                                   kind_keyword->GetText() + "'");
+    return false;
+  }
+
   auto shader_kind = tokenizer_->NextToken();
   if (shader_kind->GetType() != Token::Type::kKeywordVertex &&
       shader_kind->GetType() != Token::Type::kKeywordFragment &&

--- a/src/libshadertrap/src/tokenizer.cc
+++ b/src/libshadertrap/src/tokenizer.cc
@@ -257,6 +257,7 @@ const std::unordered_map<std::string, Token::Type>
         {"INDEX_DATA", Token::Type::kKeywordIndexData},
         {"INIT_TYPE", Token::Type::kKeywordInitType},
         {"INIT_VALUES", Token::Type::kKeywordInitValues},
+        {"KIND", Token::Type::kKeywordKind},
         {"LINEAR", Token::Type::kKeywordLinear},
         {"LOCATION", Token::Type::kKeywordLocation},
         {"NAME", Token::Type::kKeywordName},

--- a/src/libshadertraptest/src/checker_test.cc
+++ b/src/libshadertraptest/src/checker_test.cc
@@ -53,7 +53,7 @@ class CheckerTestFixture : public ::testing::Test {
 };
 
 TEST_F(CheckerTestFixture, RedeclareShader) {
-  std::string program = R"(DECLARE_SHADER s VERTEX
+  std::string program = R"(DECLARE_SHADER s KIND VERTEX
 #version 320 es
 layout(location = 0) in vec2 _GLF_vertexPosition;
 void main(void) {
@@ -61,7 +61,7 @@ void main(void) {
 }
 END
 
-DECLARE_SHADER s VERTEX
+DECLARE_SHADER s KIND VERTEX
 #version 320 es
 layout(location = 0) in vec2 _GLF_vertexPosition;
 void main(void) {
@@ -82,7 +82,7 @@ END
 
 TEST_F(CheckerTestFixture, GlslangParseError) {
   // glslang should fail to parse the program.
-  std::string program = R"(DECLARE_SHADER s VERTEX
+  std::string program = R"(DECLARE_SHADER s KIND VERTEX
 notversion
 END
   )";
@@ -104,7 +104,7 @@ END
 TEST_F(CheckerTestFixture, GlslangPrecisionError) {
   // glslang will complain that a float is declared with no default precision
   // qualifier.
-  std::string program = R"(DECLARE_SHADER s FRAGMENT
+  std::string program = R"(DECLARE_SHADER s KIND FRAGMENT
 #version 320 es
 float f;
 void main() {
@@ -143,7 +143,7 @@ TEST_F(CheckerTestFixture, CompileShaderUnknownShader) {
 }
 
 TEST_F(CheckerTestFixture, CompileShaderNameAlreadyUsed) {
-  std::string program = R"(DECLARE_SHADER s VERTEX
+  std::string program = R"(DECLARE_SHADER s KIND VERTEX
 #version 320 es
 layout(location = 0) in vec2 _GLF_vertexPosition;
 void main(void) {
@@ -165,7 +165,7 @@ COMPILE_SHADER s SHADER s
 }
 
 TEST_F(CheckerTestFixture, CreateBufferNameAlreadyUsed) {
-  std::string program = R"(DECLARE_SHADER vert VERTEX
+  std::string program = R"(DECLARE_SHADER vert KIND VERTEX
 #version 320 es
 void main() { }
 END
@@ -184,12 +184,12 @@ CREATE_BUFFER vert SIZE_BYTES 8 INIT_VALUES float 1.0 2.0
 }
 
 TEST_F(CheckerTestFixture, CreateProgramUnknownShader) {
-  std::string program = R"(DECLARE_SHADER vert VERTEX
+  std::string program = R"(DECLARE_SHADER vert KIND VERTEX
 #version 320 es
 void main() { }
 END
 
-DECLARE_SHADER frag FRAGMENT
+DECLARE_SHADER frag KIND FRAGMENT
 #version 320 es
 void main() { }
 END
@@ -213,12 +213,12 @@ CREATE_PROGRAM prog SHADERS vert_compiled mysampler frag_compiled
 }
 
 TEST_F(CheckerTestFixture, CreateProgramNameAlreadyUsed) {
-  std::string program = R"(DECLARE_SHADER vert VERTEX
+  std::string program = R"(DECLARE_SHADER vert KIND VERTEX
 #version 320 es
 void main() { }
 END
 
-DECLARE_SHADER frag FRAGMENT
+DECLARE_SHADER frag KIND FRAGMENT
 #version 320 es
 void main() { }
 END
@@ -239,7 +239,7 @@ CREATE_PROGRAM frag_compiled SHADERS vert_compiled frag_compiled
 }
 
 TEST_F(CheckerTestFixture, CreateProgramNoFragmentShader) {
-  std::string program = R"(DECLARE_SHADER vert VERTEX
+  std::string program = R"(DECLARE_SHADER vert KIND VERTEX
 #version 320 es
 void main() { }
 END
@@ -260,7 +260,7 @@ CREATE_PROGRAM prog SHADERS vert_compiled
 }
 
 TEST_F(CheckerTestFixture, CreateProgramNoVertexShader) {
-  std::string program = R"(DECLARE_SHADER frag FRAGMENT
+  std::string program = R"(DECLARE_SHADER frag KIND FRAGMENT
 #version 320 es
 void main() { }
 END
@@ -281,12 +281,12 @@ CREATE_PROGRAM prog SHADERS frag_compiled
 }
 
 TEST_F(CheckerTestFixture, CreateProgramMultipleFragmentShaders) {
-  std::string program = R"(DECLARE_SHADER vert VERTEX
+  std::string program = R"(DECLARE_SHADER vert KIND VERTEX
 #version 320 es
 void main() { }
 END
 
-DECLARE_SHADER frag FRAGMENT
+DECLARE_SHADER frag KIND FRAGMENT
 #version 320 es
 void main() { }
 END
@@ -309,12 +309,12 @@ CREATE_PROGRAM prog SHADERS vert_compiled frag_compiled frag_compiled
 }
 
 TEST_F(CheckerTestFixture, CreateProgramMultipleVertexShaders) {
-  std::string program = R"(DECLARE_SHADER vert VERTEX
+  std::string program = R"(DECLARE_SHADER vert KIND VERTEX
 #version 320 es
 void main() { }
 END
 
-DECLARE_SHADER frag FRAGMENT
+DECLARE_SHADER frag KIND FRAGMENT
 #version 320 es
 void main() { }
 END
@@ -337,7 +337,7 @@ CREATE_PROGRAM prog SHADERS frag_compiled vert_compiled vert_compiled
 }
 
 TEST_F(CheckerTestFixture, CreateProgramMultipleComputeShaders) {
-  std::string program = R"(DECLARE_SHADER comp COMPUTE
+  std::string program = R"(DECLARE_SHADER comp KIND COMPUTE
 #version 320 es
 void main() { }
 END
@@ -359,12 +359,12 @@ CREATE_PROGRAM prog SHADERS comp_compiled comp_compiled
 }
 
 TEST_F(CheckerTestFixture, CreateProgramComputeAndFragmentShaders) {
-  std::string program = R"(DECLARE_SHADER comp COMPUTE
+  std::string program = R"(DECLARE_SHADER comp KIND COMPUTE
 #version 320 es
 void main() { }
 END
 
-DECLARE_SHADER frag FRAGMENT
+DECLARE_SHADER frag KIND FRAGMENT
 #version 320 es
 void main() { }
 END
@@ -389,12 +389,12 @@ CREATE_PROGRAM prog SHADERS frag_compiled comp_compiled
 }
 
 TEST_F(CheckerTestFixture, CreateProgramComputeAndVertexShaders) {
-  std::string program = R"(DECLARE_SHADER comp COMPUTE
+  std::string program = R"(DECLARE_SHADER comp KIND COMPUTE
 #version 320 es
 void main() { }
 END
 
-DECLARE_SHADER vert VERTEX
+DECLARE_SHADER vert KIND VERTEX
 #version 320 es
 void main() { }
 END
@@ -419,7 +419,7 @@ CREATE_PROGRAM prog SHADERS comp_compiled vert_compiled
 }
 
 TEST_F(CheckerTestFixture, CreateRenderbufferNameAlreadyUsed) {
-  std::string program = R"(DECLARE_SHADER vert VERTEX
+  std::string program = R"(DECLARE_SHADER vert KIND VERTEX
 #version 320 es
 void main() { }
 END
@@ -840,10 +840,10 @@ TEST_F(CheckerTestFixture, RunComputeNonexistentProgram) {
 
 TEST_F(CheckerTestFixture, RunComputeWithGraphicsProgram) {
   std::string program =
-      R"(DECLARE_SHADER frag FRAGMENT
+      R"(DECLARE_SHADER frag KIND FRAGMENT
 void main() { }
 END
-DECLARE_SHADER vert VERTEX
+DECLARE_SHADER vert KIND VERTEX
 void main() { }
 END
 COMPILE_SHADER frag_compiled SHADER frag
@@ -865,7 +865,7 @@ RUN_COMPUTE PROGRAM prog NUM_GROUPS 1 1 1
 
 TEST_F(CheckerTestFixture, RunGraphicsNonexistentProgram) {
   std::string program =
-      R"(DECLARE_SHADER frag FRAGMENT
+      R"(DECLARE_SHADER frag KIND FRAGMENT
 #version 320 es
 precision highp float;
 layout(location = 0) out vec4 color;
@@ -874,7 +874,7 @@ void main() {
 }
 END
 
-DECLARE_SHADER vert VERTEX
+DECLARE_SHADER vert KIND VERTEX
 #version 320 es
 layout(location = 0) in vec2 pos;
 void main(void) {
@@ -919,7 +919,7 @@ RUN_GRAPHICS
 
 TEST_F(CheckerTestFixture, RunGraphicsNonexistentVertexBuffer) {
   std::string program =
-      R"(DECLARE_SHADER frag FRAGMENT
+      R"(DECLARE_SHADER frag KIND FRAGMENT
 #version 320 es
 precision highp float;
 layout(location = 0) out vec4 color;
@@ -928,7 +928,7 @@ void main() {
 }
 END
 
-DECLARE_SHADER vert VERTEX
+DECLARE_SHADER vert KIND VERTEX
 #version 320 es
 layout(location = 0) in vec2 pos;
 void main(void) {
@@ -970,7 +970,7 @@ RUN_GRAPHICS
 
 TEST_F(CheckerTestFixture, RunGraphicsNonexistentIndexBuffer) {
   std::string program =
-      R"(DECLARE_SHADER frag FRAGMENT
+      R"(DECLARE_SHADER frag KIND FRAGMENT
 #version 320 es
 precision highp float;
 layout(location = 0) out vec4 color;
@@ -979,7 +979,7 @@ void main() {
 }
 END
 
-DECLARE_SHADER vert VERTEX
+DECLARE_SHADER vert KIND VERTEX
 #version 320 es
 layout(location = 0) in vec2 pos;
 void main(void) {
@@ -1023,7 +1023,7 @@ RUN_GRAPHICS
 
 TEST_F(CheckerTestFixture, RunGraphicsNonexistentFramebufferAttachment) {
   std::string program =
-      R"(DECLARE_SHADER frag FRAGMENT
+      R"(DECLARE_SHADER frag KIND FRAGMENT
 #version 320 es
 precision highp float;
 layout(location = 0) out vec4 color;
@@ -1032,7 +1032,7 @@ void main() {
 }
 END
 
-DECLARE_SHADER vert VERTEX
+DECLARE_SHADER vert KIND VERTEX
 #version 320 es
 layout(location = 0) in vec2 pos;
 void main(void) {
@@ -1079,7 +1079,7 @@ RUN_GRAPHICS
 
 TEST_F(CheckerTestFixture, RunGraphicsWithComputeProgram) {
   std::string program =
-      R"(DECLARE_SHADER comp COMPUTE
+      R"(DECLARE_SHADER comp KIND COMPUTE
 #version 320 es
 void main() { }
 END

--- a/src/libshadertraptest/src/parser_test.cc
+++ b/src/libshadertraptest/src/parser_test.cc
@@ -37,7 +37,7 @@ TEST(ParserTest, NoShaders) {
 }
 
 TEST(ParserTest, ShaderStartsOnSameLineAsDeclaration) {
-  std::string program = R"(DECLARE_SHADER s FRAGMENT version 320 es
+  std::string program = R"(DECLARE_SHADER s KIND FRAGMENT version 320 es
 void main() {
 }
 END
@@ -48,13 +48,13 @@ END
   ASSERT_FALSE(parser.Parse());
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ(
-      "ERROR: 1:18: Shader text should begin on the line directly following "
+      "ERROR: 1:23: Shader text should begin on the line directly following "
       "the 'FRAGMENT' keyword",
       message_consumer.GetMessageString(0));
 }
 
 TEST(ParserTest, WarningIfVersionStringStartsOnSameLineAsDeclaration) {
-  std::string program = R"(DECLARE_SHADER s FRAGMENT        #version 320 es
+  std::string program = R"(DECLARE_SHADER s KIND FRAGMENT        #version 320 es
 void main() {
 }
 END
@@ -65,7 +65,7 @@ END
   ASSERT_TRUE(parser.Parse());
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ(
-      "WARNING: 1:34: '#version ...' will be treated as a comment. If it is "
+      "WARNING: 1:39: '#version ...' will be treated as a comment. If it is "
       "supposed to be the first line of shader code, it should start on the "
       "following line",
       message_consumer.GetMessageString(0));
@@ -73,7 +73,7 @@ END
 
 TEST(ParserTest, SetUniformNameAndValue) {
   std::string program =
-      R"(DECLARE_SHADER shader COMPUTE
+      R"(DECLARE_SHADER shader KIND COMPUTE
 layout(location = 1) uniform float f;
 void main() {
   f;


### PR DESCRIPTION
The pattern followed for all other ShaderTrap commands is that every
parameter is named. For DECLARE_SHADER there is only one parameter -
the kind of the shader - and it had seemed a bit redundant to force it
to be named, but actually for consistency this seems like a good
idea. This change requires a shader to be declared using:

DECLARE_SHADER result KIND VERTEX|FRAGMENT|COMPUTE
// Text
END