### PR TITLE
Improve Actions hygiene

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
       LINUX_CXX: ${{ matrix.linux_cxx }}
     steps:
 
-      - name: Cancel previous
+      - name: cancel_previous
         uses: styfle/cancel-workflow-action@0.8.0
         with:
           access_token: ${{ github.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,11 @@ jobs:
       LINUX_CXX: ${{ matrix.linux_cxx }}
     steps:
 
+      - name: Cancel previous
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+
       - name: get_actions
         run: |
           mkdir -p ./../.github/actions/

--- a/.github/workflows/dev_build.yml
+++ b/.github/workflows/dev_build.yml
@@ -23,6 +23,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
+      - name: Cancel previous
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+
       - name: get_actions
         run: |
           mkdir -p ./../.github/actions/

--- a/.github/workflows/dev_build.yml
+++ b/.github/workflows/dev_build.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
-      - name: Cancel previous
+      - name: cancel_previous
         uses: styfle/cancel-workflow-action@0.8.0
         with:
           access_token: ${{ github.token }}


### PR DESCRIPTION
👋 hello there! I'm a fellow Googler who works on projects that leverage GitHub Actions for CI/CD. Recently I noticed a large increase in our queue time, and I've tracked it down to the [limit of 180 concurrent jobs](https://docs.github.com/en/actions/reference/usage-limits-billing-and-administration) for an organization. To help be better citizens, I'm proposing changes across a few repositories that will reduce GitHub Actions hours and consumption. I hope these changes are reasonable and I'm happy to talk through them in more detail.

- **(you were already doing this, thank you!)** Only run GitHub Actions for pushes and PRs against the main branch of the repository. If your team uses a forking model, this change will not affect you. If your team pushes branches to the repository directly, this changes actions to only run against the primary branches or if you open a Pull Request against a primary branch.

- For long-running jobs (especially tests), I added the "Cancel previous" workflow. This is very helpful to prevent a large queue backlog when you are doing rapid development and pushing multiple commits. Without this, GitHub Actions' default behavior is to run all actions on all commits.

There are other changes you could make, depending on your project (but I'm not an expert):

- If you have tests that should only run when a subset of code changes, consider gating your workflow to particular file paths. For example, we have some jobs that do Terraform linting, but [they only run when Terraform files are changed](https://github.com/google/exposure-notifications-verification-server/blob/c4f59fee71042cf668747e599e7c769fca736554/.github/workflows/terraform.yml#L3-L11).

Hopefully these changes are not too controversial and also hopefully you can see how this would reduce actions consumption to be good citizens to fellow Googlers. If you have any questions, feel free to respond here or ping me on chat. Thank you!