### PR TITLE
Avoid unsupported GLES 2 calls

### DIFF
--- a/src/libshadertrap/include/libshadertrap/checker.h
+++ b/src/libshadertrap/include/libshadertrap/checker.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "libshadertrap/api_version.h"
 #include "libshadertrap/command_assert_equal.h"
 #include "libshadertrap/command_assert_pixels.h"
 #include "libshadertrap/command_assert_similar_emd_histogram.h"
@@ -43,14 +44,13 @@
 #include "libshadertrap/command_visitor.h"
 #include "libshadertrap/glslang.h"
 #include "libshadertrap/message_consumer.h"
-#include "libshadertrap/shadertrap_program.h"
 #include "libshadertrap/token.h"
 
 namespace shadertrap {
 
 class Checker : public CommandVisitor {
  public:
-  Checker(MessageConsumer* message_consumer, ShaderTrapProgram* program);
+  Checker(MessageConsumer* message_consumer, ApiVersion api_version);
 
   bool VisitAssertEqual(CommandAssertEqual* assert_equal) override;
 
@@ -118,7 +118,7 @@ class Checker : public CommandVisitor {
                                         const Token& renderbuffer_token_2);
 
   MessageConsumer* message_consumer_;
-  ShaderTrapProgram* program_;
+  ApiVersion api_version_;
   std::unordered_map<std::string, const Token&> used_identifiers_;
   std::unordered_map<std::string, CommandDeclareShader*> declared_shaders_;
   std::unordered_map<std::string, CommandCompileShader*> compiled_shaders_;

--- a/src/libshadertrap/include/libshadertrap/executor.h
+++ b/src/libshadertrap/include/libshadertrap/executor.h
@@ -21,6 +21,7 @@
 #include <map>
 #include <string>
 
+#include "libshadertrap/api_version.h"
 #include "libshadertrap/command_assert_equal.h"
 #include "libshadertrap/command_assert_pixels.h"
 #include "libshadertrap/command_assert_similar_emd_histogram.h"
@@ -49,8 +50,8 @@ namespace shadertrap {
 
 class Executor : public CommandVisitor {
  public:
-  explicit Executor(GlFunctions* gl_functions,
-                    MessageConsumer* message_consumer);
+  Executor(GlFunctions* gl_functions, MessageConsumer* message_consumer,
+           ApiVersion api_version);
 
   bool VisitAssertEqual(CommandAssertEqual* assert_equal) override;
 
@@ -107,6 +108,7 @@ class Executor : public CommandVisitor {
 
   GlFunctions* gl_functions_;
   MessageConsumer* message_consumer_;
+  ApiVersion api_version_;
   std::map<std::string, CommandDeclareShader*> declared_shaders_;
   std::map<std::string, GLuint> created_buffers_;
   std::map<std::string, GLuint> created_programs_;

--- a/src/libshadertraptest/src/checker_test.cc
+++ b/src/libshadertraptest/src/checker_test.cc
@@ -18,6 +18,7 @@
 
 #include "libshadertrap/glslang.h"
 #include "libshadertrap/parser.h"
+#include "libshadertrap/shadertrap_program.h"
 #include "libshadertraptest/collecting_message_consumer.h"
 #include "libshadertraptest/gtest.h"
 
@@ -74,8 +75,9 @@ END
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1U, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 10:16: Identifier 's' already used at 2:16",
             message_consumer.GetMessageString(0));
@@ -92,8 +94,9 @@ END
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1U, message_consumer.GetNumMessages());
   ASSERT_TRUE(message_consumer.GetMessageString(0).find(
                   "ERROR: 2:1: Validation of shader 's' using glslang failed "
@@ -118,8 +121,9 @@ END
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_TRUE(message_consumer.GetMessageString(0).find(
                   "ERROR: 2:1: Validation of shader 's' using glslang failed "
                   "with the following messages:") != std::string::npos);
@@ -137,8 +141,9 @@ COMPILE_SHADER result SHADER nonexistent
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1U, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 2:30: Identifier 'nonexistent' does not correspond to a declared "
@@ -162,8 +167,9 @@ COMPILE_SHADER s SHADER s
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1U, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 10:16: Identifier 's' already used at 2:16",
             message_consumer.GetMessageString(0));
@@ -182,8 +188,9 @@ CREATE_BUFFER vert SIZE_BYTES 8 INIT_VALUES float 1.0 2.0
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 7:15: Identifier 'vert' already used at 2:16",
             message_consumer.GetMessageString(0));
@@ -210,8 +217,9 @@ CREATE_PROGRAM prog SHADERS vert_compiled mysampler frag_compiled
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1U, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 15:43: Identifier 'mysampler' does not correspond to a compiled "
@@ -239,8 +247,9 @@ CREATE_PROGRAM frag_compiled SHADERS vert_compiled frag_compiled
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1U, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 14:16: Identifier 'frag_compiled' already used at 13:16",
             message_consumer.GetMessageString(0));
@@ -260,8 +269,9 @@ CREATE_PROGRAM prog SHADERS vert_compiled
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1U, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 8:1: No fragment shader provided for 'CREATE_PROGRAM' command",
@@ -282,8 +292,9 @@ CREATE_PROGRAM prog SHADERS frag_compiled
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1U, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 8:1: No vertex shader provided for 'CREATE_PROGRAM' command",
@@ -310,8 +321,9 @@ CREATE_PROGRAM prog SHADERS vert_compiled frag_compiled frag_compiled
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1U, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 14:57: Multiple fragment shaders provided to 'CREATE_PROGRAM'; "
@@ -339,8 +351,9 @@ CREATE_PROGRAM prog SHADERS frag_compiled vert_compiled vert_compiled
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1U, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 14:57: Multiple vertex shaders provided to 'CREATE_PROGRAM'; "
@@ -362,8 +375,9 @@ CREATE_PROGRAM prog SHADERS comp_compiled comp_compiled
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1U, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 8:43: Multiple compute shaders provided to 'CREATE_PROGRAM'; "
@@ -391,8 +405,9 @@ CREATE_PROGRAM prog SHADERS frag_compiled comp_compiled
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1U, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 14:43: A compute shader cannot be used in 'CREATE_PROGRAM' with "
@@ -422,8 +437,9 @@ CREATE_PROGRAM prog SHADERS comp_compiled vert_compiled
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1U, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 14:29: A compute shader cannot be used in 'CREATE_PROGRAM' with "
@@ -446,8 +462,9 @@ CREATE_RENDERBUFFER vert WIDTH 24 HEIGHT 24
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 7:21: Identifier 'vert' already used at 2:16",
             message_consumer.GetMessageString(0));
@@ -462,8 +479,9 @@ CREATE_SAMPLER name
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 3:16: Identifier 'name' already used at 2:25",
             message_consumer.GetMessageString(0));
@@ -478,8 +496,9 @@ CREATE_EMPTY_TEXTURE_2D name WIDTH 12 HEIGHT 12
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 3:25: Identifier 'name' already used at 2:25",
             message_consumer.GetMessageString(0));
@@ -495,8 +514,9 @@ ASSERT_EQUAL RENDERBUFFERS buf1 buf2
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 4:33: width 2 of 'buf2' does not match width 1 of 'buf1' at 4:28",
@@ -513,8 +533,9 @@ ASSERT_EQUAL RENDERBUFFERS buf1 buf2
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 4:33: height 2 of 'buf2' does not match height 1 of 'buf1' at "
@@ -533,8 +554,9 @@ ASSERT_EQUAL BUFFERS buf1 buf2
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 4:27: size (in bytes) 8 of 'buf2' does not match size (in bytes) "
@@ -553,8 +575,9 @@ ASSERT_EQUAL BUFFERS buf1 buf2
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 4:27: 'buf2' must be a buffer",
             message_consumer.GetMessageString(0));
@@ -569,8 +592,9 @@ ASSERT_EQUAL RENDERBUFFERS buf1 buf2
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 3:28: 'buf1' must be a renderbuffer",
             message_consumer.GetMessageString(0));
@@ -586,8 +610,9 @@ ASSERT_EQUAL RENDERBUFFERS buf1 buf2
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 4:33: 'buf2' must be a renderbuffer",
             message_consumer.GetMessageString(0));
@@ -604,8 +629,9 @@ ASSERT_EQUAL BUFFERS buf1 buf2
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 4:27: 'buf2' must be a buffer",
             message_consumer.GetMessageString(0));
@@ -621,8 +647,9 @@ ASSERT_PIXELS RENDERBUFFER buf RECTANGLE 0 0 2 2 EXPECTED 0 0 0 0
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 3:28: 'buf' is not a renderbuffer",
             message_consumer.GetMessageString(0));
@@ -638,8 +665,9 @@ ASSERT_PIXELS RENDERBUFFER buf RECTANGLE 8 8 9 8 EXPECTED 0 0 0 0
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 3:46: rectangle extends to x-coordinate 17, which exceeds width "
@@ -657,8 +685,9 @@ ASSERT_PIXELS RENDERBUFFER buf RECTANGLE 8 8 8 9 EXPECTED 0 0 0 0
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 3:48: rectangle extends to y-coordinate 17, which exceeds height "
@@ -676,8 +705,9 @@ ASSERT_PIXELS RENDERBUFFER buf RECTANGLE 8 8 0 8 EXPECTED 0 0 0 0
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 3:46: width of rectangle must be positive",
             message_consumer.GetMessageString(0));
@@ -693,8 +723,9 @@ ASSERT_PIXELS RENDERBUFFER buf RECTANGLE 8 8 8 0 EXPECTED 0 0 0 0
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 3:48: height of rectangle must be positive",
             message_consumer.GetMessageString(0));
@@ -709,8 +740,9 @@ ASSERT_SIMILAR_EMD_HISTOGRAM RENDERBUFFERS buf1 buf2 TOLERANCE 1.0
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 3:44: 'buf1' must be a renderbuffer",
             message_consumer.GetMessageString(0));
@@ -725,8 +757,9 @@ ASSERT_SIMILAR_EMD_HISTOGRAM RENDERBUFFERS buf1 buf2 TOLERANCE 1.0
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 3:49: 'buf2' must be a renderbuffer",
             message_consumer.GetMessageString(0));
@@ -742,8 +775,9 @@ ASSERT_SIMILAR_EMD_HISTOGRAM RENDERBUFFERS buf1 buf2 TOLERANCE 1.0
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 4:49: width 20 of 'buf2' does not match width 24 of 'buf1' at "
@@ -761,8 +795,9 @@ ASSERT_SIMILAR_EMD_HISTOGRAM RENDERBUFFERS buf1 buf2 TOLERANCE 1.0
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 4:49: height 28 of 'buf2' does not match height 24 of 'buf1' at "
@@ -778,8 +813,9 @@ BIND_SAMPLER SAMPLER doesnotexist TEXTURE_UNIT 1
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 2:22: 'doesnotexist' must be a sampler",
             message_consumer.GetMessageString(0));
@@ -794,8 +830,9 @@ BIND_SHADER_STORAGE_BUFFER BUFFER doesnotexist BINDING 1
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 2:35: 'doesnotexist' must be a buffer",
             message_consumer.GetMessageString(0));
@@ -809,8 +846,9 @@ BIND_TEXTURE TEXTURE doesnotexist TEXTURE_UNIT 1
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 2:22: 'doesnotexist' must be a texture",
             message_consumer.GetMessageString(0));
@@ -824,8 +862,9 @@ BIND_UNIFORM_BUFFER BUFFER doesnotexist BINDING 1
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 2:28: 'doesnotexist' must be a buffer",
             message_consumer.GetMessageString(0));
@@ -840,8 +879,9 @@ DUMP_RENDERBUFFER RENDERBUFFER doesnotexist FILE "temp.png"
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 2:32: 'doesnotexist' must be a renderbuffer",
             message_consumer.GetMessageString(0));
@@ -856,8 +896,9 @@ SET_UNIFORM PROGRAM prog LOCATION 1 TYPE float VALUES 0.1
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 2:21: 'prog' must be a program",
             message_consumer.GetMessageString(0));
@@ -872,8 +913,9 @@ RUN_COMPUTE PROGRAM prog NUM_GROUPS 1 1 1
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 2:21: 'prog' must be a program",
             message_consumer.GetMessageString(0));
@@ -897,8 +939,9 @@ RUN_COMPUTE PROGRAM prog NUM_GROUPS 1 1 1
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 11:21: 'prog' must be a compute program, not a graphics program",
@@ -953,8 +996,9 @@ RUN_GRAPHICS
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 34:11: 'nonexistent' must be a program",
             message_consumer.GetMessageString(0));
@@ -1005,8 +1049,9 @@ RUN_GRAPHICS
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 33:19: vertex buffer 'nonexistent' must be a buffer",
             message_consumer.GetMessageString(0));
@@ -1059,8 +1104,9 @@ RUN_GRAPHICS
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 36:14: index buffer 'nonexistent' must be a buffer",
             message_consumer.GetMessageString(0));
@@ -1114,8 +1160,9 @@ RUN_GRAPHICS
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 41:12: framebuffer attachment 'nonexistent' must be a "
@@ -1159,8 +1206,9 @@ RUN_GRAPHICS
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 22:11: 'program' must be a graphics program, not a compute "
@@ -1176,8 +1224,9 @@ SET_SAMPLER_PARAMETER PARAMETER TEXTURE_MAG_FILTER VALUE LINEAR SAMPLER nonexist
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 2:73: 'nonexistent' must be a sampler",
             message_consumer.GetMessageString(0));
@@ -1191,8 +1240,9 @@ SET_TEXTURE_PARAMETER VALUE NEAREST PARAMETER TEXTURE_MIN_FILTER TEXTURE nonexis
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ("ERROR: 2:74: 'nonexistent' must be a texture",
             message_consumer.GetMessageString(0));
@@ -1209,8 +1259,9 @@ END
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 2:1: Compute shaders are not supported before OpenGL 4.3 or "
@@ -1229,12 +1280,72 @@ END
   CollectingMessageConsumer message_consumer;
   Parser parser(program, &message_consumer);
   ASSERT_TRUE(parser.Parse());
-  Checker checker(&message_consumer, parser.GetParsedProgram().get());
-  ASSERT_FALSE(checker.VisitCommands(parser.GetParsedProgram().get()));
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
   ASSERT_EQ(1, message_consumer.GetNumMessages());
   ASSERT_EQ(
       "ERROR: 2:1: Compute shaders are not supported before OpenGL 4.3 or "
       "OpenGL ES 3.1",
+      message_consumer.GetMessageString(0));
+}
+
+TEST_F(CheckerTestFixture, OnlyUseColorAttachment0WithGles2) {
+  std::string program =
+      R"(GLES 2.0
+
+DECLARE_SHADER frag KIND FRAGMENT
+#version 100
+precision highp float;
+void main() {
+ gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+}
+END
+
+DECLARE_SHADER vert KIND VERTEX
+#version 100
+varying vec2 a_pos;
+void main(void) {
+    gl_Position = vec4(a_pos, 0.0, 1.0);
+}
+END
+
+COMPILE_SHADER frag_compiled SHADER frag
+
+COMPILE_SHADER vert_compiled SHADER vert
+
+CREATE_PROGRAM program SHADERS vert_compiled frag_compiled
+
+CREATE_BUFFER vertex_buffer SIZE_BYTES 24 INIT_VALUES float
+                           0.0 -1.0
+                           -1.0 1.0
+                            1.0 1.0
+
+CREATE_BUFFER index_buffer SIZE_BYTES 12 INIT_VALUES uint
+                           0 1 2
+
+CREATE_RENDERBUFFER renderbuffer WIDTH 256 HEIGHT 256
+
+RUN_GRAPHICS
+  PROGRAM program
+  VERTEX_DATA
+    [ 0 -> BUFFER vertex_buffer OFFSET_BYTES 0 STRIDE_BYTES 8 DIMENSION 2 ]
+  INDEX_DATA index_buffer
+  VERTEX_COUNT 3
+  TOPOLOGY TRIANGLES
+  FRAMEBUFFER_ATTACHMENTS
+    [ 1 -> renderbuffer ]
+)";
+  CollectingMessageConsumer message_consumer;
+  Parser parser(program, &message_consumer);
+  ASSERT_TRUE(parser.Parse());
+  auto parsed_program = parser.GetParsedProgram();
+  Checker checker(&message_consumer, parsed_program->GetApiVersion());
+  ASSERT_FALSE(checker.VisitCommands(parsed_program.get()));
+  ASSERT_EQ(1, message_consumer.GetNumMessages());
+  ASSERT_EQ(
+      "ERROR: 43:12: Only 0 may be used as a framebuffer attachment key when "
+      "working with OpenGL ES 2.0",
       message_consumer.GetMessageString(0));
 }
 

--- a/src/libshadertraptest/src/parser_test.cc
+++ b/src/libshadertraptest/src/parser_test.cc
@@ -217,5 +217,120 @@ CREATE_BUFFER buf SIZE_BYTES 51 INIT_VALUES
       message_consumer.GetMessageString(0));
 }
 
+TEST(ParserTest, NoDuplicateColorAttachmentKeys) {
+  std::string program =
+      R"(GLES 3.2
+
+DECLARE_SHADER frag KIND FRAGMENT
+#version 320 es
+precision highp float;
+layout(location = 0) out vec4 color;
+void main() {
+ color = vec4(1.0, 0.0, 0.0, 1.0);
+}
+END
+
+DECLARE_SHADER vert KIND VERTEX
+#version 320 es
+layout(location = 0) in vec2 pos;
+void main(void) {
+    gl_Position = vec4(a_pos, 0.0, 1.0);
+}
+END
+
+COMPILE_SHADER frag_compiled SHADER frag
+
+COMPILE_SHADER vert_compiled SHADER vert
+
+CREATE_PROGRAM program SHADERS vert_compiled frag_compiled
+
+CREATE_BUFFER vertex_buffer SIZE_BYTES 24 INIT_VALUES float
+                           0.0 -1.0
+                           -1.0 1.0
+                            1.0 1.0
+
+CREATE_BUFFER index_buffer SIZE_BYTES 12 INIT_VALUES uint
+                           0 1 2
+
+CREATE_RENDERBUFFER renderbuffer WIDTH 256 HEIGHT 256
+CREATE_RENDERBUFFER renderbuffer2 WIDTH 256 HEIGHT 256
+
+RUN_GRAPHICS
+  PROGRAM program
+  VERTEX_DATA
+    [ 0 -> BUFFER vertex_buffer OFFSET_BYTES 0 STRIDE_BYTES 8 DIMENSION 2 ]
+  INDEX_DATA index_buffer
+  VERTEX_COUNT 3
+  TOPOLOGY TRIANGLES
+  FRAMEBUFFER_ATTACHMENTS
+    [ 0 -> renderbuffer, 0 -> renderbuffer2 ]
+)";
+  CollectingMessageConsumer message_consumer;
+  Parser parser(program, &message_consumer);
+  ASSERT_FALSE(parser.Parse());
+  ASSERT_EQ(1, message_consumer.GetNumMessages());
+  ASSERT_EQ("ERROR: 45:26: Duplicate key: 0 is already used as a key at 45:7",
+            message_consumer.GetMessageString(0));
+}
+
+TEST(ParserTest, NoDuplicateColorAttachmentValues) {
+  std::string program =
+      R"(GLES 3.2
+
+DECLARE_SHADER frag KIND FRAGMENT
+#version 320 es
+precision highp float;
+layout(location = 0) out vec4 color;
+layout(location = 1) out vec4 color;
+void main() {
+ color = vec4(1.0, 0.0, 0.0, 1.0);
+ color2 = vec4(1.0, 0.0, 0.0, 1.0);
+}
+END
+
+DECLARE_SHADER vert KIND VERTEX
+#version 320 es
+layout(location = 0) in vec2 pos;
+void main(void) {
+    gl_Position = vec4(a_pos, 0.0, 1.0);
+}
+END
+
+COMPILE_SHADER frag_compiled SHADER frag
+
+COMPILE_SHADER vert_compiled SHADER vert
+
+CREATE_PROGRAM program SHADERS vert_compiled frag_compiled
+
+CREATE_BUFFER vertex_buffer SIZE_BYTES 24 INIT_VALUES float
+                           0.0 -1.0
+                           -1.0 1.0
+                            1.0 1.0
+
+CREATE_BUFFER index_buffer SIZE_BYTES 12 INIT_VALUES uint
+                           0 1 2
+
+CREATE_RENDERBUFFER renderbuffer WIDTH 256 HEIGHT 256
+
+RUN_GRAPHICS
+  PROGRAM program
+  VERTEX_DATA
+    [ 0 -> BUFFER vertex_buffer OFFSET_BYTES 0 STRIDE_BYTES 8 DIMENSION 2 ]
+  INDEX_DATA index_buffer
+  VERTEX_COUNT 3
+  TOPOLOGY TRIANGLES
+  FRAMEBUFFER_ATTACHMENTS
+    [ 0 -> renderbuffer, 1 -> renderbuffer ]
+)";
+  CollectingMessageConsumer message_consumer;
+  Parser parser(program, &message_consumer);
+  ASSERT_FALSE(parser.Parse());
+  ASSERT_EQ(1, message_consumer.GetNumMessages());
+  ASSERT_EQ(
+      "ERROR: 46:31: Duplicate attachment: 'renderbuffer' is already attached "
+      "at 46:12",
+      message_consumer.GetMessageString(0));
+}
+
 }  // namespace
 }  // namespace shadertrap

--- a/src/shadertrap/src/main.cc
+++ b/src/shadertrap/src/main.cc
@@ -205,9 +205,9 @@ int main(int argc, const char** argv) {
 
   std::vector<std::unique_ptr<shadertrap::CommandVisitor>> temp;
   temp.push_back(shadertrap::MakeUnique<shadertrap::Checker>(
-      &message_consumer, shadertrap_program.get()));
+      &message_consumer, shadertrap_program->GetApiVersion()));
   temp.push_back(shadertrap::MakeUnique<shadertrap::Executor>(
-      &functions, &message_consumer));
+      &functions, &message_consumer, shadertrap_program->GetApiVersion()));
   shadertrap::CompoundVisitor checker_and_executor(std::move(temp));
   ShInitialize();
   bool success = checker_and_executor.VisitCommands(shadertrap_program.get());


### PR DESCRIPTION
Fixes #36.

Also improves the checking of framebuffer attachments to reject
duplicate locations or the same buffer being attached multiple times.