### PR TITLE
Specify buffer layout in examples

### DIFF
--- a/examples/GLES31/flag.shadertrap
+++ b/examples/GLES31/flag.shadertrap
@@ -23,12 +23,12 @@ precision highp float;
 
 layout(location = 0) uniform float aninput;
 
-layout(binding = 0) uniform buf1 {
+layout(std140, binding = 0) uniform buf1 {
   float one;
   float zero;
 };
 
-layout(binding = 1) uniform buf2 {
+layout(std140, binding = 1) uniform buf2 {
   uint uone;
   uint uzero;
   uint uthree;

--- a/examples/GLES31/prefixsum.shadertrap
+++ b/examples/GLES31/prefixsum.shadertrap
@@ -31,7 +31,7 @@ DECLARE_SHADER shader KIND COMPUTE
 
 layout(local_size_x=8, local_size_y=1, local_size_z=1) in;
 
-layout(binding=0) buffer data_buffer{
+layout(std430, binding=0) buffer data_buffer{
   int[16] data;
 };
 

--- a/examples/GLES31/simplecompute.shadertrap
+++ b/examples/GLES31/simplecompute.shadertrap
@@ -25,7 +25,7 @@ DECLARE_SHADER shader KIND COMPUTE
 
 layout(local_size_x=1, local_size_y=1, local_size_z=1) in;
 
-layout(binding = 0) buffer ssbo {
+layout(std140, binding = 0) buffer ssbo {
   uint data;
 };
 

--- a/examples/GLES31/simplecompute_with_named_uniform.shadertrap
+++ b/examples/GLES31/simplecompute_with_named_uniform.shadertrap
@@ -25,7 +25,7 @@ DECLARE_SHADER shader KIND COMPUTE
 
 layout(local_size_x=1, local_size_y=1, local_size_z=1) in;
 
-layout(binding = 0) buffer ssbo {
+layout(std140, binding = 0) buffer ssbo {
   uint data;
 };
 

--- a/examples/OpenGL45/arrayaddition.shadertrap
+++ b/examples/OpenGL45/arrayaddition.shadertrap
@@ -28,13 +28,13 @@ DECLARE_SHADER shader KIND COMPUTE
 
 layout(local_size_x=1, local_size_y=1, local_size_z=1) in;
 
-layout(binding = 0) buffer array1 {
+layout(std430, binding = 0) buffer array1 {
   uint[10] data1;
 };
-layout(binding=1) buffer array2 {
+layout(std430, binding=1) buffer array2 {
   uint[10] data2;
 };
-layout(binding=2) buffer result{
+layout(std430, binding=2) buffer result{
   uint[10] res;
 };
 


### PR DESCRIPTION
The uniform and shader storage buffers in the examples did not specify
a layout. This change introduces appropriate layout qualifiers.