### PR TITLE
Improvements to uniform handling

### DIFF
--- a/src/libshadertrap/src/executor.cc
+++ b/src/libshadertrap/src/executor.cc
@@ -877,11 +877,13 @@ bool Executor::VisitSetUniform(CommandSetUniform* set_uniform) {
     GL_CHECKERR(&set_uniform->GetStartToken(), "glGetUniformLocation");
     if (uniform_location == -1) {
       message_consumer_->Message(
-          MessageConsumer::Severity::kError, &set_uniform->GetNameToken(),
+          MessageConsumer::Severity::kWarning, &set_uniform->GetNameToken(),
           "Program '" + set_uniform->GetProgramIdentifier() +
               "' does not have a uniform named '" + set_uniform->GetName() +
-              "'");
-      return false;
+              "'. This can happen even when a uniform is present in one of the "
+              "program's shaders, if the uniform is identified as redundant "
+              "and optimized away.");
+      return true;
     }
   }
   const UniformValue& uniform_value = set_uniform->GetValue();
@@ -1037,6 +1039,69 @@ bool Executor::VisitSetUniform(CommandSetUniform* set_uniform) {
                     uniform_value.GetUintData()[3]);
       }
       break;
+    case UniformValue::ElementType::kMat2x2: {
+      size_t count = uniform_value.IsArray() ? uniform_value.GetArraySize() : 1;
+      GL_SAFECALL(&set_uniform->GetStartToken(), glProgramUniformMatrix2fv,
+                  program, uniform_location, count, GL_FALSE,
+                  uniform_value.GetFloatData());
+      break;
+    }
+    case UniformValue::ElementType::kMat2x3: {
+      size_t count = uniform_value.IsArray() ? uniform_value.GetArraySize() : 1;
+      GL_SAFECALL(&set_uniform->GetStartToken(), glProgramUniformMatrix2x3fv,
+                  program, uniform_location, count, GL_FALSE,
+                  uniform_value.GetFloatData());
+      break;
+    }
+    case UniformValue::ElementType::kMat2x4: {
+      size_t count = uniform_value.IsArray() ? uniform_value.GetArraySize() : 1;
+      GL_SAFECALL(&set_uniform->GetStartToken(), glProgramUniformMatrix2x4fv,
+                  program, uniform_location, count, GL_FALSE,
+                  uniform_value.GetFloatData());
+      break;
+    }
+    case UniformValue::ElementType::kMat3x2: {
+      size_t count = uniform_value.IsArray() ? uniform_value.GetArraySize() : 1;
+      GL_SAFECALL(&set_uniform->GetStartToken(), glProgramUniformMatrix3x2fv,
+                  program, uniform_location, count, GL_FALSE,
+                  uniform_value.GetFloatData());
+      break;
+    }
+    case UniformValue::ElementType::kMat3x3: {
+      size_t count = uniform_value.IsArray() ? uniform_value.GetArraySize() : 1;
+      GL_SAFECALL(&set_uniform->GetStartToken(), glProgramUniformMatrix3fv,
+                  program, uniform_location, count, GL_FALSE,
+                  uniform_value.GetFloatData());
+      break;
+    }
+    case UniformValue::ElementType::kMat3x4: {
+      size_t count = uniform_value.IsArray() ? uniform_value.GetArraySize() : 1;
+      GL_SAFECALL(&set_uniform->GetStartToken(), glProgramUniformMatrix3x4fv,
+                  program, uniform_location, count, GL_FALSE,
+                  uniform_value.GetFloatData());
+      break;
+    }
+    case UniformValue::ElementType::kMat4x2: {
+      size_t count = uniform_value.IsArray() ? uniform_value.GetArraySize() : 1;
+      GL_SAFECALL(&set_uniform->GetStartToken(), glProgramUniformMatrix4x2fv,
+                  program, uniform_location, count, GL_FALSE,
+                  uniform_value.GetFloatData());
+      break;
+    }
+    case UniformValue::ElementType::kMat4x3: {
+      size_t count = uniform_value.IsArray() ? uniform_value.GetArraySize() : 1;
+      GL_SAFECALL(&set_uniform->GetStartToken(), glProgramUniformMatrix4x3fv,
+                  program, uniform_location, count, GL_FALSE,
+                  uniform_value.GetFloatData());
+      break;
+    }
+    case UniformValue::ElementType::kMat4x4: {
+      size_t count = uniform_value.IsArray() ? uniform_value.GetArraySize() : 1;
+      GL_SAFECALL(&set_uniform->GetStartToken(), glProgramUniformMatrix4fv,
+                  program, uniform_location, count, GL_FALSE,
+                  uniform_value.GetFloatData());
+      break;
+    }
     default:
       assert(false && "Unhandled uniform type.");
       break;

--- a/src/libshadertrap/src/executor.cc
+++ b/src/libshadertrap/src/executor.cc
@@ -1042,64 +1042,64 @@ bool Executor::VisitSetUniform(CommandSetUniform* set_uniform) {
     case UniformValue::ElementType::kMat2x2: {
       size_t count = uniform_value.IsArray() ? uniform_value.GetArraySize() : 1;
       GL_SAFECALL(&set_uniform->GetStartToken(), glProgramUniformMatrix2fv,
-                  program, uniform_location, count, GL_FALSE,
-                  uniform_value.GetFloatData());
+                  program, uniform_location, static_cast<GLsizei>(count),
+                  GL_FALSE, uniform_value.GetFloatData());
       break;
     }
     case UniformValue::ElementType::kMat2x3: {
       size_t count = uniform_value.IsArray() ? uniform_value.GetArraySize() : 1;
       GL_SAFECALL(&set_uniform->GetStartToken(), glProgramUniformMatrix2x3fv,
-                  program, uniform_location, count, GL_FALSE,
-                  uniform_value.GetFloatData());
+                  program, uniform_location, static_cast<GLsizei>(count),
+                  GL_FALSE, uniform_value.GetFloatData());
       break;
     }
     case UniformValue::ElementType::kMat2x4: {
       size_t count = uniform_value.IsArray() ? uniform_value.GetArraySize() : 1;
       GL_SAFECALL(&set_uniform->GetStartToken(), glProgramUniformMatrix2x4fv,
-                  program, uniform_location, count, GL_FALSE,
-                  uniform_value.GetFloatData());
+                  program, uniform_location, static_cast<GLsizei>(count),
+                  GL_FALSE, uniform_value.GetFloatData());
       break;
     }
     case UniformValue::ElementType::kMat3x2: {
       size_t count = uniform_value.IsArray() ? uniform_value.GetArraySize() : 1;
       GL_SAFECALL(&set_uniform->GetStartToken(), glProgramUniformMatrix3x2fv,
-                  program, uniform_location, count, GL_FALSE,
-                  uniform_value.GetFloatData());
+                  program, uniform_location, static_cast<GLsizei>(count),
+                  GL_FALSE, uniform_value.GetFloatData());
       break;
     }
     case UniformValue::ElementType::kMat3x3: {
       size_t count = uniform_value.IsArray() ? uniform_value.GetArraySize() : 1;
       GL_SAFECALL(&set_uniform->GetStartToken(), glProgramUniformMatrix3fv,
-                  program, uniform_location, count, GL_FALSE,
-                  uniform_value.GetFloatData());
+                  program, uniform_location, static_cast<GLsizei>(count),
+                  GL_FALSE, uniform_value.GetFloatData());
       break;
     }
     case UniformValue::ElementType::kMat3x4: {
       size_t count = uniform_value.IsArray() ? uniform_value.GetArraySize() : 1;
       GL_SAFECALL(&set_uniform->GetStartToken(), glProgramUniformMatrix3x4fv,
-                  program, uniform_location, count, GL_FALSE,
-                  uniform_value.GetFloatData());
+                  program, uniform_location, static_cast<GLsizei>(count),
+                  GL_FALSE, uniform_value.GetFloatData());
       break;
     }
     case UniformValue::ElementType::kMat4x2: {
       size_t count = uniform_value.IsArray() ? uniform_value.GetArraySize() : 1;
       GL_SAFECALL(&set_uniform->GetStartToken(), glProgramUniformMatrix4x2fv,
-                  program, uniform_location, count, GL_FALSE,
-                  uniform_value.GetFloatData());
+                  program, uniform_location, static_cast<GLsizei>(count),
+                  GL_FALSE, uniform_value.GetFloatData());
       break;
     }
     case UniformValue::ElementType::kMat4x3: {
       size_t count = uniform_value.IsArray() ? uniform_value.GetArraySize() : 1;
       GL_SAFECALL(&set_uniform->GetStartToken(), glProgramUniformMatrix4x3fv,
-                  program, uniform_location, count, GL_FALSE,
-                  uniform_value.GetFloatData());
+                  program, uniform_location, static_cast<GLsizei>(count),
+                  GL_FALSE, uniform_value.GetFloatData());
       break;
     }
     case UniformValue::ElementType::kMat4x4: {
       size_t count = uniform_value.IsArray() ? uniform_value.GetArraySize() : 1;
       GL_SAFECALL(&set_uniform->GetStartToken(), glProgramUniformMatrix4fv,
-                  program, uniform_location, count, GL_FALSE,
-                  uniform_value.GetFloatData());
+                  program, uniform_location, static_cast<GLsizei>(count),
+                  GL_FALSE, uniform_value.GetFloatData());
       break;
     }
   }

--- a/src/libshadertrap/src/executor.cc
+++ b/src/libshadertrap/src/executor.cc
@@ -1102,9 +1102,6 @@ bool Executor::VisitSetUniform(CommandSetUniform* set_uniform) {
                   uniform_value.GetFloatData());
       break;
     }
-    default:
-      assert(false && "Unhandled uniform type.");
-      break;
   }
   return true;
 }


### PR DESCRIPTION
Issues a warning instead of an error when a named uniform is not found
- this is important because named uniforms can be optimized away.

Adds support for setting matrix uniforms.